### PR TITLE
feat: add BaseInput and BaseTextarea form components

### DIFF
--- a/docs/superpowers/plans/2026-03-18-form-components.md
+++ b/docs/superpowers/plans/2026-03-18-form-components.md
@@ -1,0 +1,237 @@
+# Form Components Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create BaseInput and BaseTextarea form components with integrated labels and error display, then refactor Contact.vue to use them.
+
+**Architecture:** Two new components in `src/components/base/` following the same pattern as existing base components (Button, Card, Badge). Both support v-model via `modelValue` + `update:modelValue`. Contact.vue is refactored to replace inline form markup with the new components.
+
+**Tech Stack:** Vue 3 Composition API, Nuxt 3 auto-imports, Tailwind CSS, TypeScript
+
+**Important constraint:** No Node/yarn on host. All commands run inside Docker. Build verification: `docker compose build && docker compose up -d`, then `curl http://localhost:3001`.
+
+**Spec:** `docs/superpowers/specs/2026-03-18-form-components-design.md`
+
+---
+
+## Chunk 1: Create Components and Refactor
+
+### Task 1: Create BaseInput
+
+**Files:**
+- Create: `src/components/base/Input.vue`
+
+- [ ] **Step 1: Create the BaseInput component**
+
+```vue
+<script setup lang="ts">
+import { computed } from 'vue'
+
+interface Props {
+  modelValue?: string
+  label?: string
+  id?: string
+  type?: 'text' | 'email' | 'password' | 'number' | 'tel' | 'url'
+  placeholder?: string
+  required?: boolean
+  disabled?: boolean
+  error?: string
+  minlength?: number
+  maxlength?: number
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  modelValue: '',
+  type: 'text',
+  required: false,
+  disabled: false,
+})
+
+const emit = defineEmits<{ 'update:modelValue': [value: string] }>()
+
+const inputId = computed(() => {
+  if (props.id) return props.id
+  if (props.label) return props.label.toLowerCase().replace(/\s+/g, '-')
+  return undefined
+})
+
+const inputClasses = computed(() => [
+  'w-full px-3 py-2 bg-tokyo-night-bg text-tokyo-night-text rounded font-mono placeholder-tokyo-night-muted transition',
+  'focus:outline-none focus:ring-2 focus:ring-tokyo-night-cyan border',
+  props.error ? 'border-tokyo-night-red' : 'border-tokyo-night-gray',
+])
+</script>
+
+<template>
+  <div class="flex flex-col gap-1">
+    <label v-if="label" :for="inputId" class="text-tokyo-night-cyan font-mono font-bold">
+      {{ label }}
+    </label>
+    <input
+      :id="inputId"
+      :type="type"
+      :value="modelValue"
+      @input="emit('update:modelValue', ($event.target as HTMLInputElement).value)"
+      :placeholder="placeholder"
+      :required="required"
+      :disabled="disabled"
+      :minlength="minlength"
+      :maxlength="maxlength"
+      :class="inputClasses"
+    />
+    <p v-if="error" class="text-tokyo-night-red font-mono text-sm mt-1">{{ error }}</p>
+  </div>
+</template>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/base/Input.vue
+git commit -m "feat(ui): add BaseInput component with label and error support"
+```
+
+---
+
+### Task 2: Create BaseTextarea
+
+**Files:**
+- Create: `src/components/base/Textarea.vue`
+
+- [ ] **Step 1: Create the BaseTextarea component**
+
+```vue
+<script setup lang="ts">
+import { computed } from 'vue'
+
+interface Props {
+  modelValue?: string
+  label?: string
+  id?: string
+  placeholder?: string
+  required?: boolean
+  disabled?: boolean
+  error?: string
+  rows?: number
+  minlength?: number
+  maxlength?: number
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  modelValue: '',
+  rows: 4,
+  required: false,
+  disabled: false,
+})
+
+const emit = defineEmits<{ 'update:modelValue': [value: string] }>()
+
+const textareaId = computed(() => {
+  if (props.id) return props.id
+  if (props.label) return props.label.toLowerCase().replace(/\s+/g, '-')
+  return undefined
+})
+
+const textareaClasses = computed(() => [
+  'w-full px-3 py-2 bg-tokyo-night-bg text-tokyo-night-text rounded font-mono placeholder-tokyo-night-muted transition',
+  'focus:outline-none focus:ring-2 focus:ring-tokyo-night-cyan border',
+  props.error ? 'border-tokyo-night-red' : 'border-tokyo-night-gray',
+])
+</script>
+
+<template>
+  <div class="flex flex-col gap-1">
+    <label v-if="label" :for="textareaId" class="text-tokyo-night-cyan font-mono font-bold">
+      {{ label }}
+    </label>
+    <textarea
+      :id="textareaId"
+      :value="modelValue"
+      @input="emit('update:modelValue', ($event.target as HTMLTextAreaElement).value)"
+      :placeholder="placeholder"
+      :required="required"
+      :disabled="disabled"
+      :rows="rows"
+      :minlength="minlength"
+      :maxlength="maxlength"
+      :class="textareaClasses"
+    />
+    <p v-if="error" class="text-tokyo-night-red font-mono text-sm mt-1">{{ error }}</p>
+  </div>
+</template>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/base/Textarea.vue
+git commit -m "feat(ui): add BaseTextarea component with label and error support"
+```
+
+---
+
+### Task 3: Refactor Contact.vue
+
+**Files:**
+- Modify: `src/components/home/Contact.vue`
+
+- [ ] **Step 1: Replace form field markup with BaseInput and BaseTextarea**
+
+Replace the template's form content (the three `<div class="flex flex-col gap-1">` blocks containing label+input/textarea, lines 6-20) with:
+
+```vue
+<BaseInput
+  v-model="form.name"
+  label="Name"
+  placeholder="Write your name"
+  required
+  :minlength="2"
+  :maxlength="100"
+/>
+<BaseInput
+  v-model="form.email"
+  label="Email"
+  type="email"
+  placeholder="email@example.com"
+  required
+/>
+<BaseTextarea
+  v-model="form.message"
+  label="Message"
+  placeholder="Write your message here"
+  required
+  :rows="4"
+  :minlength="10"
+  :maxlength="1000"
+/>
+```
+
+Keep the error/success divs and BaseButton submit unchanged.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/home/Contact.vue
+git commit -m "refactor(ui): use BaseInput and BaseTextarea in Contact form"
+```
+
+---
+
+### Task 4: Verify build
+
+- [ ] **Step 1: Build and test dev image**
+
+```bash
+docker compose build
+docker compose up -d
+sleep 20
+curl -s -o /dev/null -w "%{http_code}" http://localhost:3001
+# Expected: 200
+docker compose down
+```
+
+- [ ] **Step 2: Close issue**
+
+```bash
+gh issue close 29
+```

--- a/docs/superpowers/specs/2026-03-18-form-components-design.md
+++ b/docs/superpowers/specs/2026-03-18-form-components-design.md
@@ -1,0 +1,149 @@
+# Design: Reusable Form Components (#29)
+
+## Goal
+
+Create BaseInput and BaseTextarea components with integrated labels and error display, then refactor Contact.vue to use them — eliminating repeated Tailwind class strings.
+
+## Scope
+
+**In scope:** BaseInput, BaseTextarea, refactor Contact.vue.
+
+**Out of scope:** BaseButton (already exists from #35), BaseLabel as standalone (integrated into input/textarea), form validation logic (stays in parent).
+
+## Tech Stack
+
+- Vue 3 Composition API with `<script setup lang="ts">`
+- Nuxt 3 auto-imports (`base/Input.vue` → `<BaseInput>`)
+- Tailwind CSS with Tokyo Night palette
+- v-model support via `modelValue` + `update:modelValue`
+
+## Shared Input Styles
+
+Both components share the same base Tailwind classes from the current Contact.vue:
+
+```
+w-full px-3 py-2 bg-tokyo-night-bg text-tokyo-night-text border border-tokyo-night-gray rounded
+focus:outline-none focus:ring-2 focus:ring-tokyo-night-cyan font-mono placeholder-tokyo-night-muted transition
+```
+
+**Error state:** Border changes to `border-tokyo-night-red` (replacing `border-tokyo-night-gray`).
+
+**Label styles:** `text-tokyo-night-cyan font-mono font-bold` (from current Contact.vue).
+
+## Components
+
+### 1. BaseInput (`src/components/base/Input.vue`)
+
+Text input with integrated label and error message.
+
+**Props:**
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `modelValue` | `string` | `''` | v-model binding |
+| `label` | `string` | — | Label text above input |
+| `id` | `string` | auto from label | HTML id for input + label `for` |
+| `type` | `'text' \| 'email' \| 'password' \| 'number' \| 'tel' \| 'url'` | `'text'` | Input type |
+| `placeholder` | `string` | — | Placeholder text |
+| `required` | `boolean` | `false` | HTML required attribute |
+| `disabled` | `boolean` | `false` | Disabled state |
+| `error` | `string` | — | Error message displayed below input |
+| `minlength` | `number` | — | HTML minlength attribute |
+| `maxlength` | `number` | — | HTML maxlength attribute |
+
+**Emits:** `update:modelValue` — for v-model support.
+
+**Auto-generated id:** If `label` is provided but `id` is not, generate id from label: `label.toLowerCase().replace(/\s+/g, '-')`.
+
+**Template structure:**
+```html
+<div class="flex flex-col gap-1">
+  <label v-if="label" :for="inputId" class="text-tokyo-night-cyan font-mono font-bold">
+    {{ label }}
+  </label>
+  <input
+    :id="inputId"
+    :type="type"
+    :value="modelValue"
+    @input="emit('update:modelValue', ($event.target as HTMLInputElement).value)"
+    :placeholder="placeholder"
+    :required="required"
+    :disabled="disabled"
+    :minlength="minlength"
+    :maxlength="maxlength"
+    :class="[baseClasses, error ? 'border-tokyo-night-red' : 'border-tokyo-night-gray']"
+  />
+  <p v-if="error" class="text-tokyo-night-red font-mono text-sm mt-1">{{ error }}</p>
+</div>
+```
+
+### 2. BaseTextarea (`src/components/base/Textarea.vue`)
+
+Textarea with integrated label and error message. Same API as BaseInput minus `type`, plus `rows`.
+
+**Props:**
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `modelValue` | `string` | `''` | v-model binding |
+| `label` | `string` | — | Label text above textarea |
+| `id` | `string` | auto from label | HTML id |
+| `placeholder` | `string` | — | Placeholder text |
+| `required` | `boolean` | `false` | HTML required |
+| `disabled` | `boolean` | `false` | Disabled state |
+| `error` | `string` | — | Error message below textarea |
+| `rows` | `number` | `4` | Textarea rows |
+| `minlength` | `number` | — | HTML minlength |
+| `maxlength` | `number` | — | HTML maxlength |
+
+**Emits:** `update:modelValue`
+
+**Template structure:** Same as BaseInput but renders `<textarea>` instead of `<input>`.
+
+## Refactoring: Contact.vue
+
+The contact form template reduces from ~20 lines of repeated markup to:
+
+```html
+<form @submit.prevent="submitForm" class="bg-tokyo-night-dark p-6 rounded-lg shadow-lg w-full flex flex-col gap-4">
+  <BaseInput
+    v-model="form.name"
+    label="Name"
+    placeholder="Write your name"
+    required
+    :minlength="2"
+    :maxlength="100"
+  />
+  <BaseInput
+    v-model="form.email"
+    label="Email"
+    type="email"
+    placeholder="email@example.com"
+    required
+  />
+  <BaseTextarea
+    v-model="form.message"
+    label="Message"
+    placeholder="Write your message here"
+    required
+    :rows="4"
+    :minlength="10"
+    :maxlength="1000"
+  />
+  <div v-if="error" class="text-red-400 font-mono">{{ error }}</div>
+  <div v-if="success" class="text-green-400 font-mono">Message sent successfully!</div>
+  <BaseButton type="submit" :loading="loading" :disabled="loading">
+    Send message
+  </BaseButton>
+</form>
+```
+
+Script section stays unchanged — validation logic, form refs, submitForm function all remain in Contact.vue.
+
+## Constraints
+
+- All components use `<script setup lang="ts">` with TypeScript interfaces
+- Follow existing Tokyo Night tokens from `tailwind.config.js`
+- No new dependencies
+- Nuxt auto-import handles registration
+- `tokyo-night-red` (`#f7768e`) is already defined in tailwind config as `red`

--- a/src/components/base/Input.vue
+++ b/src/components/base/Input.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+interface Props {
+  modelValue?: string
+  label?: string
+  id?: string
+  type?: 'text' | 'email' | 'password' | 'number' | 'tel' | 'url'
+  placeholder?: string
+  required?: boolean
+  disabled?: boolean
+  error?: string
+  minlength?: number
+  maxlength?: number
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  modelValue: '',
+  type: 'text',
+  required: false,
+  disabled: false,
+})
+
+const emit = defineEmits<{ 'update:modelValue': [value: string] }>()
+
+const inputId = computed(() => {
+  if (props.id) return props.id
+  if (props.label) return props.label.toLowerCase().replace(/\s+/g, '-')
+  return undefined
+})
+
+const inputClasses = computed(() => [
+  'w-full px-3 py-2 bg-tokyo-night-bg text-tokyo-night-text rounded font-mono placeholder-tokyo-night-muted transition',
+  'focus:outline-none focus:ring-2 focus:ring-tokyo-night-cyan border',
+  props.error ? 'border-tokyo-night-red' : 'border-tokyo-night-gray',
+])
+</script>
+
+<template>
+  <div class="flex flex-col gap-1">
+    <label v-if="label" :for="inputId" class="text-tokyo-night-cyan font-mono font-bold">
+      {{ label }}
+    </label>
+    <input
+      :id="inputId"
+      :type="type"
+      :value="modelValue"
+      @input="emit('update:modelValue', ($event.target as HTMLInputElement).value)"
+      :placeholder="placeholder"
+      :required="required"
+      :disabled="disabled"
+      :minlength="minlength"
+      :maxlength="maxlength"
+      :class="inputClasses"
+    />
+    <p v-if="error" class="text-tokyo-night-red font-mono text-sm mt-1">{{ error }}</p>
+  </div>
+</template>

--- a/src/components/base/Input.vue
+++ b/src/components/base/Input.vue
@@ -29,6 +29,8 @@ const inputId = computed(() => {
   return undefined
 })
 
+const errorId = computed(() => props.error && inputId.value ? `${inputId.value}-error` : undefined)
+
 const inputClasses = computed(() => [
   'w-full px-3 py-2 bg-tokyo-night-bg text-tokyo-night-text rounded font-mono placeholder-tokyo-night-muted transition',
   'focus:outline-none focus:ring-2 focus:ring-tokyo-night-cyan border',
@@ -52,7 +54,9 @@ const inputClasses = computed(() => [
       :minlength="minlength"
       :maxlength="maxlength"
       :class="inputClasses"
+      :aria-invalid="error ? true : undefined"
+      :aria-describedby="errorId"
     />
-    <p v-if="error" class="text-tokyo-night-red font-mono text-sm mt-1">{{ error }}</p>
+    <p v-if="error" :id="errorId" class="text-tokyo-night-red font-mono text-sm mt-1">{{ error }}</p>
   </div>
 </template>

--- a/src/components/base/Textarea.vue
+++ b/src/components/base/Textarea.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+interface Props {
+  modelValue?: string
+  label?: string
+  id?: string
+  placeholder?: string
+  required?: boolean
+  disabled?: boolean
+  error?: string
+  rows?: number
+  minlength?: number
+  maxlength?: number
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  modelValue: '',
+  rows: 4,
+  required: false,
+  disabled: false,
+})
+
+const emit = defineEmits<{ 'update:modelValue': [value: string] }>()
+
+const textareaId = computed(() => {
+  if (props.id) return props.id
+  if (props.label) return props.label.toLowerCase().replace(/\s+/g, '-')
+  return undefined
+})
+
+const textareaClasses = computed(() => [
+  'w-full px-3 py-2 bg-tokyo-night-bg text-tokyo-night-text rounded font-mono placeholder-tokyo-night-muted transition',
+  'focus:outline-none focus:ring-2 focus:ring-tokyo-night-cyan border',
+  props.error ? 'border-tokyo-night-red' : 'border-tokyo-night-gray',
+])
+</script>
+
+<template>
+  <div class="flex flex-col gap-1">
+    <label v-if="label" :for="textareaId" class="text-tokyo-night-cyan font-mono font-bold">
+      {{ label }}
+    </label>
+    <textarea
+      :id="textareaId"
+      :value="modelValue"
+      @input="emit('update:modelValue', ($event.target as HTMLTextAreaElement).value)"
+      :placeholder="placeholder"
+      :required="required"
+      :disabled="disabled"
+      :rows="rows"
+      :minlength="minlength"
+      :maxlength="maxlength"
+      :class="textareaClasses"
+    />
+    <p v-if="error" class="text-tokyo-night-red font-mono text-sm mt-1">{{ error }}</p>
+  </div>
+</template>

--- a/src/components/base/Textarea.vue
+++ b/src/components/base/Textarea.vue
@@ -29,6 +29,8 @@ const textareaId = computed(() => {
   return undefined
 })
 
+const errorId = computed(() => props.error && textareaId.value ? `${textareaId.value}-error` : undefined)
+
 const textareaClasses = computed(() => [
   'w-full px-3 py-2 bg-tokyo-night-bg text-tokyo-night-text rounded font-mono placeholder-tokyo-night-muted transition',
   'focus:outline-none focus:ring-2 focus:ring-tokyo-night-cyan border',
@@ -52,7 +54,9 @@ const textareaClasses = computed(() => [
       :minlength="minlength"
       :maxlength="maxlength"
       :class="textareaClasses"
+      :aria-invalid="error ? true : undefined"
+      :aria-describedby="errorId"
     />
-    <p v-if="error" class="text-tokyo-night-red font-mono text-sm mt-1">{{ error }}</p>
+    <p v-if="error" :id="errorId" class="text-tokyo-night-red font-mono text-sm mt-1">{{ error }}</p>
   </div>
 </template>

--- a/src/components/home/Contact.vue
+++ b/src/components/home/Contact.vue
@@ -3,21 +3,30 @@
     <BaseSectionHeading title="Contact me :)" animated :level="3" />
     <div>
       <form @submit.prevent="submitForm" class="bg-tokyo-night-dark p-6 rounded-lg shadow-lg w-full flex flex-col gap-4">
-        <div class="flex flex-col gap-1">
-          <label for="name" class="text-tokyo-night-cyan font-mono font-bold">Name</label>
-          <input v-model="form.name" type="text" id="name" placeholder="Write your name" required minlength="2" maxlength="100"
-            class="w-full px-3 py-2 bg-tokyo-night-bg text-tokyo-night-text border border-tokyo-night-gray rounded focus:outline-none focus:ring-2 focus:ring-tokyo-night-cyan font-mono placeholder-tokyo-night-muted transition" />
-        </div>
-        <div class="flex flex-col gap-1">
-          <label for="email" class="text-tokyo-night-cyan font-mono font-bold">Email</label>
-          <input v-model="form.email" type="email" id="email" placeholder="email@example.com" required
-            class="w-full px-3 py-2 bg-tokyo-night-bg text-tokyo-night-text border border-tokyo-night-gray rounded focus:outline-none focus:ring-2 focus:ring-tokyo-night-cyan font-mono placeholder-tokyo-night-muted transition" />
-        </div>
-        <div class="flex flex-col gap-1">
-          <label for="message" class="text-tokyo-night-cyan font-mono font-bold">Message</label>
-          <textarea v-model="form.message" id="message" rows="4" placeholder="Write your message here" required minlength="10" maxlength="1000"
-            class="w-full px-3 py-2 bg-tokyo-night-bg text-tokyo-night-text border border-tokyo-night-gray rounded focus:outline-none focus:ring-2 focus:ring-tokyo-night-cyan font-mono placeholder-tokyo-night-muted transition"></textarea>
-        </div>
+        <BaseInput
+          v-model="form.name"
+          label="Name"
+          placeholder="Write your name"
+          required
+          :minlength="2"
+          :maxlength="100"
+        />
+        <BaseInput
+          v-model="form.email"
+          label="Email"
+          type="email"
+          placeholder="email@example.com"
+          required
+        />
+        <BaseTextarea
+          v-model="form.message"
+          label="Message"
+          placeholder="Write your message here"
+          required
+          :rows="4"
+          :minlength="10"
+          :maxlength="1000"
+        />
         <div v-if="error" class="text-red-400 font-mono">{{ error }}</div>
         <div v-if="success" class="text-green-400 font-mono">Message sent successfully!</div>
 

--- a/src/components/home/Contact.vue
+++ b/src/components/home/Contact.vue
@@ -27,8 +27,8 @@
           :minlength="10"
           :maxlength="1000"
         />
-        <div v-if="error" class="text-red-400 font-mono">{{ error }}</div>
-        <div v-if="success" class="text-green-400 font-mono">Message sent successfully!</div>
+        <div v-if="error" class="text-tokyo-night-red font-mono">{{ error }}</div>
+        <div v-if="success" class="text-tokyo-night-green font-mono">Message sent successfully!</div>
 
         <BaseButton type="submit" :loading="loading" :disabled="loading">
           Send message


### PR DESCRIPTION
## Summary
- Created `BaseInput` component with integrated label, v-model support, and error display
- Created `BaseTextarea` component with same API pattern plus `rows` prop
- Refactored `Contact.vue` to use new components — eliminated ~15 lines of repeated Tailwind classes

## Test Plan
- [x] Dev image builds successfully
- [x] Dev server returns HTTP 200
- [ ] Visual verification: contact form renders and functions correctly

Closes #29