### PR TITLE
feat: add accessible toast notification system

### DIFF
--- a/docs/superpowers/plans/2026-03-18-toast-component.md
+++ b/docs/superpowers/plans/2026-03-18-toast-component.md
@@ -1,0 +1,355 @@
+# Toast Notification System Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create an accessible toast notification system with composable API, replacing inline success/error messages in Contact.vue.
+
+**Architecture:** `useToast` composable manages a singleton toast queue via Nuxt `useState`. `BaseToast` component renders the stack fixed top-right with ARIA live regions, auto-dismiss with pause-on-hover, and CSS transitions. Contact.vue is refactored to use `toast.success()` / `toast.error()` for API responses.
+
+**Tech Stack:** Vue 3 Composition API, Nuxt 3 useState, Tailwind CSS, TypeScript
+
+**Important constraint:** No Node/yarn on host. Docker build verification: `docker compose build && docker compose up -d`, then `curl http://localhost:3001`.
+
+**Spec:** `docs/superpowers/specs/2026-03-18-toast-component-design.md`
+
+---
+
+## Chunk 1: Toast System + Refactor
+
+### Task 1: Create useToast composable
+
+**Files:**
+- Create: `src/composables/useToast.ts`
+
+- [ ] **Step 1: Create the composable**
+
+```typescript
+export interface ToastItem {
+  id: string
+  message: string
+  type: 'success' | 'error' | 'warning' | 'info'
+  duration: number
+}
+
+type ToastType = ToastItem['type']
+
+const DEFAULT_DURATIONS: Record<ToastType, number> = {
+  success: 5000,
+  info: 5000,
+  warning: 0,
+  error: 0,
+}
+
+export function useToast() {
+  const toasts = useState<ToastItem[]>('toasts', () => [])
+
+  function show(options: { message: string; type?: ToastType; duration?: number }): string {
+    const type = options.type ?? 'info'
+    const id = Date.now().toString(36) + Math.random().toString(36).slice(2)
+    const toast: ToastItem = {
+      id,
+      message: options.message,
+      type,
+      duration: options.duration ?? DEFAULT_DURATIONS[type],
+    }
+    toasts.value.push(toast)
+    return id
+  }
+
+  function remove(id: string) {
+    toasts.value = toasts.value.filter((t) => t.id !== id)
+  }
+
+  function clear() {
+    toasts.value = []
+  }
+
+  function success(message: string, duration?: number) {
+    return show({ message, type: 'success', duration })
+  }
+
+  function error(message: string, duration?: number) {
+    return show({ message, type: 'error', duration })
+  }
+
+  function warning(message: string, duration?: number) {
+    return show({ message, type: 'warning', duration })
+  }
+
+  function info(message: string, duration?: number) {
+    return show({ message, type: 'info', duration })
+  }
+
+  return { toasts, show, remove, clear, success, error, warning, info }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/composables/useToast.ts
+git commit -m "feat(ui): add useToast composable with singleton state"
+```
+
+---
+
+### Task 2: Create BaseToast component
+
+**Files:**
+- Create: `src/components/base/Toast.vue`
+
+- [ ] **Step 1: Create the component**
+
+```vue
+<script setup lang="ts">
+import { onUnmounted } from 'vue'
+import { useToast, type ToastItem } from '~/composables/useToast'
+
+const { toasts, remove } = useToast()
+
+const timers = new Map<string, { timeout: ReturnType<typeof setTimeout>; remaining: number; start: number }>()
+
+function startTimer(toast: ToastItem) {
+  if (toast.duration <= 0) return
+  const start = Date.now()
+  const timeout = setTimeout(() => {
+    remove(toast.id)
+    timers.delete(toast.id)
+  }, toast.duration)
+  timers.set(toast.id, { timeout, remaining: toast.duration, start })
+}
+
+function pauseTimer(id: string) {
+  const timer = timers.get(id)
+  if (!timer) return
+  clearTimeout(timer.timeout)
+  timer.remaining -= Date.now() - timer.start
+}
+
+function resumeTimer(id: string) {
+  const timer = timers.get(id)
+  if (!timer || timer.remaining <= 0) return
+  timer.start = Date.now()
+  timer.timeout = setTimeout(() => {
+    remove(id)
+    timers.delete(id)
+  }, timer.remaining)
+}
+
+function onToastEnter(toast: ToastItem) {
+  startTimer(toast)
+}
+
+function onClose(id: string) {
+  const timer = timers.get(id)
+  if (timer) {
+    clearTimeout(timer.timeout)
+    timers.delete(id)
+  }
+  remove(id)
+}
+
+onUnmounted(() => {
+  timers.forEach((timer) => clearTimeout(timer.timeout))
+  timers.clear()
+})
+
+const typeConfig: Record<string, { border: string; icon: string; iconColor: string }> = {
+  success: { border: 'border-tokyo-night-green', icon: '✓', iconColor: 'text-tokyo-night-green' },
+  error: { border: 'border-tokyo-night-red', icon: '✕', iconColor: 'text-tokyo-night-red' },
+  warning: { border: 'border-tokyo-night-yellow', icon: '⚠', iconColor: 'text-tokyo-night-yellow' },
+  info: { border: 'border-tokyo-night-cyan', icon: 'ℹ', iconColor: 'text-tokyo-night-cyan' },
+}
+</script>
+
+<template>
+  <div
+    class="fixed top-4 right-4 z-50 flex flex-col gap-3 w-80"
+    role="region"
+    aria-label="Notifications"
+  >
+    <TransitionGroup name="toast">
+      <div
+        v-for="toast in toasts"
+        :key="toast.id"
+        :class="[
+          'bg-tokyo-night-dark rounded-lg border border-l-4 p-3 font-mono text-sm shadow-lg',
+          'flex items-start gap-3',
+          typeConfig[toast.type].border,
+        ]"
+        role="alert"
+        @mouseenter="pauseTimer(toast.id)"
+        @mouseleave="resumeTimer(toast.id)"
+        @vue:mounted="onToastEnter(toast)"
+      >
+        <span :class="[typeConfig[toast.type].iconColor, 'text-base leading-none shrink-0']">
+          {{ typeConfig[toast.type].icon }}
+        </span>
+        <span class="text-tokyo-night-text flex-1 break-words">{{ toast.message }}</span>
+        <button
+          @click="onClose(toast.id)"
+          class="text-tokyo-night-muted hover:text-tokyo-night-text text-base leading-none shrink-0 cursor-pointer"
+          aria-label="Close notification"
+          @focus="pauseTimer(toast.id)"
+          @blur="resumeTimer(toast.id)"
+        >
+          ×
+        </button>
+      </div>
+    </TransitionGroup>
+  </div>
+</template>
+
+<style scoped>
+.toast-enter-active {
+  transition: all 0.3s ease-out;
+}
+.toast-leave-active {
+  transition: all 0.2s ease-in;
+}
+.toast-enter-from {
+  opacity: 0;
+  transform: translateX(100%);
+}
+.toast-leave-to {
+  opacity: 0;
+  transform: translateX(100%);
+}
+</style>
+```
+
+Note on `@vue:mounted`: This is a Vue 3 lifecycle event on the element that fires when each toast item enters the DOM — used to start the auto-dismiss timer. Alternative: use a `watch` on `toasts` array to start timers for new items.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/base/Toast.vue
+git commit -m "feat(ui): add BaseToast component with ARIA live regions and auto-dismiss"
+```
+
+---
+
+### Task 3: Mount BaseToast in app.vue
+
+**Files:**
+- Modify: `src/app.vue`
+
+- [ ] **Step 1: Add BaseToast after the root div**
+
+In `src/app.vue`, add `<BaseToast />` just before the closing `</template>`, after the root `<div>`:
+
+```vue
+<template>
+  <div class="flex flex-col min-h-screen bg-tokyo-night-bg text-tokyo-night-text font-mono">
+    <NuxtLoadingIndicator :height="1" :throttle="100" color="#f471B5" />
+    <NuxtRouteAnnouncer>
+      <template #default="{ message }">
+        <p>{{ message }} was loaded.</p>
+      </template>
+    </NuxtRouteAnnouncer>
+    <!-- Header -->
+    <Header />
+    <!-- Main Content -->
+    <main class="container mx-auto p-4 flex-grow">
+      <NuxtPage />
+    </main>
+    <!-- Footer -->
+    <Footer />
+  </div>
+  <BaseToast />
+</template>
+```
+
+`<BaseToast />` is outside the main div so it's not affected by the page layout's flex container. It uses `position: fixed` so it renders on top of everything.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app.vue
+git commit -m "feat(ui): mount BaseToast in app.vue for global notifications"
+```
+
+---
+
+### Task 4: Refactor Contact.vue to use toast
+
+**Files:**
+- Modify: `src/components/home/Contact.vue`
+
+- [ ] **Step 1: Replace API success/error with toast calls**
+
+In the `<script>` section, add at the top (after imports):
+```typescript
+const toast = useToast()
+```
+
+In `submitForm()`, replace the success block:
+```typescript
+// OLD:
+success.value = true;
+form.value = { name: '', email: '', message: '', subject: '' };
+
+// NEW:
+toast.success('Message sent successfully!')
+form.value = { name: '', email: '', message: '', subject: '' };
+```
+
+Replace the API error block:
+```typescript
+// OLD:
+const msg = data.error?.message || 'Failed to send message';
+error.value = msg;
+
+// NEW:
+const msg = data.error?.message || 'Failed to send message';
+toast.error(msg);
+```
+
+Replace the network error catch:
+```typescript
+// OLD:
+error.value = 'Network error. Please try again.';
+
+// NEW:
+toast.error('Network error. Please try again.');
+```
+
+Remove the `success` ref declaration (line `const success = ref(false);`).
+
+Remove the inline success div from the template:
+```html
+<!-- REMOVE THIS LINE: -->
+<div v-if="success" class="text-tokyo-night-green font-mono">Message sent successfully!</div>
+```
+
+Keep the `error` ref and the inline `<div v-if="error">` — they're still used by `validateForm()` for inline validation messages.
+
+In `submitForm()`, keep `error.value = null;` at the start (resets validation errors). But don't set `error.value` for API/network errors anymore — those go to toast.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/home/Contact.vue
+git commit -m "refactor(ui): use toast notifications for Contact form API feedback"
+```
+
+---
+
+### Task 5: Verify build
+
+- [ ] **Step 1: Build and test**
+
+```bash
+docker compose build
+docker compose up -d
+sleep 20
+curl -s -o /dev/null -w "%{http_code}" http://localhost:3001
+# Expected: 200
+docker compose down
+```
+
+- [ ] **Step 2: Close issue**
+
+```bash
+gh issue close 28
+```

--- a/docs/superpowers/specs/2026-03-18-toast-component-design.md
+++ b/docs/superpowers/specs/2026-03-18-toast-component-design.md
@@ -1,0 +1,171 @@
+# Design: Accessible Toast Notification System (#28)
+
+## Goal
+
+Create a toast notification system with ARIA live regions, replacing inline success/error messages in Contact.vue with transient, accessible toast notifications.
+
+## Scope
+
+**In scope:** `useToast` composable, `BaseToast` component, refactor Contact.vue to use toasts.
+
+**Out of scope:** Persistent notifications, notification history, notification center.
+
+## Tech Stack
+
+- Vue 3 Composition API with `<script setup lang="ts">`
+- Nuxt 3 `useState` for SSR-safe singleton state
+- Tailwind CSS with Tokyo Night palette
+- No external dependencies
+
+## Architecture
+
+Two pieces:
+
+| Piece | File | Purpose |
+|-------|------|---------|
+| `useToast` composable | `src/composables/useToast.ts` | Singleton state + `show()` / `remove()` / shorthand API |
+| `BaseToast` component | `src/components/base/Toast.vue` | Renders toast stack, ARIA live region, auto-dismiss timers |
+
+**Data flow:** Component calls `useToast().success('msg')` → composable adds toast to reactive array via `useState` → `BaseToast` (mounted once in `app.vue`) renders the stack → auto-dismiss or manual close removes it.
+
+## useToast Composable (`src/composables/useToast.ts`)
+
+### Toast Item Interface
+
+```typescript
+interface ToastItem {
+  id: string
+  message: string
+  type: 'success' | 'error' | 'warning' | 'info'
+  duration: number  // ms, 0 = no auto-dismiss
+}
+```
+
+### API
+
+```typescript
+interface UseToastReturn {
+  toasts: Ref<ToastItem[]>
+  show: (options: { message: string; type?: ToastItem['type']; duration?: number }) => string
+  success: (message: string, duration?: number) => string
+  error: (message: string, duration?: number) => string
+  warning: (message: string, duration?: number) => string
+  info: (message: string, duration?: number) => string
+  remove: (id: string) => void
+  clear: () => void
+}
+```
+
+### Default Durations
+
+| Type | Duration | Behavior |
+|------|----------|----------|
+| `success` | 5000ms | Auto-dismiss |
+| `info` | 5000ms | Auto-dismiss |
+| `warning` | 0 | Stays until closed |
+| `error` | 0 | Stays until closed |
+
+Callers can override duration per toast (e.g., `toast.success('Done', 3000)`).
+
+### Singleton State
+
+Uses `useState<ToastItem[]>('toasts', () => [])` for SSR-safe shared state across all components.
+
+### ID Generation
+
+Each toast gets a unique id: `Date.now().toString(36) + Math.random().toString(36).slice(2)`.
+
+## BaseToast Component (`src/components/base/Toast.vue`)
+
+### Position
+
+Fixed top-right: `fixed top-4 right-4 z-50`. Toasts stack vertically with `flex flex-col gap-3`.
+
+### Visual Design per Type
+
+All toasts share: `bg-tokyo-night-dark rounded-lg border border-l-4 p-3 font-mono text-sm shadow-lg`
+
+| Type | Border/Left color | Icon |
+|------|-------------------|------|
+| `success` | `border-tokyo-night-green` | `✓` in `text-tokyo-night-green` |
+| `error` | `border-tokyo-night-red` | `✕` in `text-tokyo-night-red` |
+| `warning` | `border-tokyo-night-yellow` | `⚠` in `text-tokyo-night-yellow` |
+| `info` | `border-tokyo-night-cyan` | `ℹ` in `text-tokyo-night-cyan` |
+
+Message text: `text-tokyo-night-text`. Close button: `text-tokyo-night-muted hover:text-tokyo-night-text`, with `aria-label="Close notification"`.
+
+### Layout per Toast
+
+```
+[icon] [message text.......................] [×]
+```
+
+Flexbox row: `flex items-start gap-3`. Icon and close button are fixed width, message fills remaining space.
+
+### Auto-dismiss
+
+- Toasts with `duration > 0` auto-remove after the specified time
+- Timer **pauses** on mouse hover or keyboard focus (a11y best practice — users need time to read)
+- Timer **resumes** on mouse leave / blur
+- Implemented with `setTimeout` + tracking remaining time on pause
+
+### Accessibility
+
+- Container: `role="region"` + `aria-label="Notifications"`
+- Each toast: `role="alert"` + `aria-live="assertive"` (screen readers announce immediately)
+- Close button: `<button aria-label="Close notification">`
+- Keyboard: close button is focusable, Escape key while focused closes the toast
+
+### Animation
+
+Simple CSS transitions:
+- Enter: slide in from right (`translate-x-full` → `translate-x-0`) + fade in
+- Exit: fade out (`opacity-0`) + slide right
+
+Use Vue's `<TransitionGroup>` with `name="toast"`.
+
+## Mounting in app.vue
+
+Add `<BaseToast />` at the root level in `src/app.vue` (or layout) so it's always available:
+
+```vue
+<template>
+  <NuxtLayout>
+    <NuxtPage />
+  </NuxtLayout>
+  <BaseToast />
+</template>
+```
+
+## Refactoring: Contact.vue
+
+Replace the inline error/success `<div>` elements (lines 30-31) with `useToast()` calls:
+
+```typescript
+const toast = useToast()
+
+// In submitForm, on success:
+toast.success('Message sent successfully!')
+
+// On API error:
+toast.error(msg)
+
+// On network error:
+toast.error('Network error. Please try again.')
+```
+
+Remove:
+- `<div v-if="error" class="text-tokyo-night-red font-mono">{{ error }}</div>`
+- `<div v-if="success" class="text-tokyo-night-green font-mono">Message sent successfully!</div>`
+- The `success` ref (no longer needed)
+- The `error` ref for form-level API errors (validation errors still stay inline via BaseInput/BaseTextarea `error` prop)
+
+Keep: The `error` ref can be repurposed or removed. Validation errors (from `validateForm()`) should stay inline on the form fields via the `error` prop on BaseInput/BaseTextarea. API/network errors go to toast.
+
+## Constraints
+
+- All components use `<script setup lang="ts">` with TypeScript interfaces
+- Follow existing Tokyo Night tokens from `tailwind.config.js`
+- No external dependencies
+- Nuxt auto-import for composable and component
+- Must work with SSR (no direct `window`/`document` access outside client guards)

--- a/docs/superpowers/specs/2026-03-18-toast-component-design.md
+++ b/docs/superpowers/specs/2026-03-18-toast-component-design.md
@@ -158,9 +158,11 @@ Remove:
 - `<div v-if="error" class="text-tokyo-night-red font-mono">{{ error }}</div>`
 - `<div v-if="success" class="text-tokyo-night-green font-mono">Message sent successfully!</div>`
 - The `success` ref (no longer needed)
-- The `error` ref for form-level API errors (validation errors still stay inline via BaseInput/BaseTextarea `error` prop)
 
-Keep: The `error` ref can be repurposed or removed. Validation errors (from `validateForm()`) should stay inline on the form fields via the `error` prop on BaseInput/BaseTextarea. API/network errors go to toast.
+Keep:
+- The `error` ref — still used by `validateForm()` to show inline validation errors in the form. Only API/network errors move to toast.
+- `validateForm()` continues to set `error.value` for display as an inline message below the form fields (this is field-level feedback, not a transient notification).
+- The inline `<div v-if="error">` stays for validation errors only. API success/error responses move to toast.
 
 ## Constraints
 

--- a/src/app.vue
+++ b/src/app.vue
@@ -15,6 +15,7 @@
     <!-- Footer -->
     <Footer />
   </div>
+  <BaseToast />
 </template>
 
 <script setup>

--- a/src/components/base/Toast.vue
+++ b/src/components/base/Toast.vue
@@ -1,0 +1,115 @@
+<script setup lang="ts">
+import { onUnmounted } from 'vue'
+import { useToast, type ToastItem } from '~/composables/useToast'
+
+const { toasts, remove } = useToast()
+
+const timers = new Map<string, { timeout: ReturnType<typeof setTimeout>; remaining: number; start: number }>()
+
+function startTimer(toast: ToastItem) {
+  if (toast.duration <= 0) return
+  const start = Date.now()
+  const timeout = setTimeout(() => {
+    remove(toast.id)
+    timers.delete(toast.id)
+  }, toast.duration)
+  timers.set(toast.id, { timeout, remaining: toast.duration, start })
+}
+
+function pauseTimer(id: string) {
+  const timer = timers.get(id)
+  if (!timer) return
+  clearTimeout(timer.timeout)
+  timer.remaining -= Date.now() - timer.start
+}
+
+function resumeTimer(id: string) {
+  const timer = timers.get(id)
+  if (!timer || timer.remaining <= 0) return
+  timer.start = Date.now()
+  timer.timeout = setTimeout(() => {
+    remove(id)
+    timers.delete(id)
+  }, timer.remaining)
+}
+
+function onToastEnter(toast: ToastItem) {
+  startTimer(toast)
+}
+
+function onClose(id: string) {
+  const timer = timers.get(id)
+  if (timer) {
+    clearTimeout(timer.timeout)
+    timers.delete(id)
+  }
+  remove(id)
+}
+
+onUnmounted(() => {
+  timers.forEach((timer) => clearTimeout(timer.timeout))
+  timers.clear()
+})
+
+const typeConfig: Record<string, { border: string; icon: string; iconColor: string }> = {
+  success: { border: 'border-tokyo-night-green', icon: '✓', iconColor: 'text-tokyo-night-green' },
+  error: { border: 'border-tokyo-night-red', icon: '✕', iconColor: 'text-tokyo-night-red' },
+  warning: { border: 'border-tokyo-night-yellow', icon: '⚠', iconColor: 'text-tokyo-night-yellow' },
+  info: { border: 'border-tokyo-night-cyan', icon: 'ℹ', iconColor: 'text-tokyo-night-cyan' },
+}
+</script>
+
+<template>
+  <div
+    class="fixed top-4 right-4 z-50 flex flex-col gap-3 w-80"
+    role="region"
+    aria-label="Notifications"
+  >
+    <TransitionGroup name="toast">
+      <div
+        v-for="toast in toasts"
+        :key="toast.id"
+        :class="[
+          'bg-tokyo-night-dark rounded-lg border border-l-4 p-3 font-mono text-sm shadow-lg',
+          'flex items-start gap-3',
+          typeConfig[toast.type].border,
+        ]"
+        role="alert"
+        @mouseenter="pauseTimer(toast.id)"
+        @mouseleave="resumeTimer(toast.id)"
+        @vue:mounted="onToastEnter(toast)"
+      >
+        <span :class="[typeConfig[toast.type].iconColor, 'text-base leading-none shrink-0']">
+          {{ typeConfig[toast.type].icon }}
+        </span>
+        <span class="text-tokyo-night-text flex-1 break-words">{{ toast.message }}</span>
+        <button
+          @click="onClose(toast.id)"
+          class="text-tokyo-night-muted hover:text-tokyo-night-text text-base leading-none shrink-0 cursor-pointer"
+          aria-label="Close notification"
+          @focus="pauseTimer(toast.id)"
+          @blur="resumeTimer(toast.id)"
+        >
+          ×
+        </button>
+      </div>
+    </TransitionGroup>
+  </div>
+</template>
+
+<style scoped>
+.toast-enter-active {
+  transition: all 0.3s ease-out;
+}
+.toast-leave-active {
+  transition: all 0.2s ease-in;
+}
+.toast-enter-from {
+  opacity: 0;
+  transform: translateX(100%);
+}
+.toast-leave-to {
+  opacity: 0;
+  transform: translateX(100%);
+}
+</style>

--- a/src/components/base/Toast.vue
+++ b/src/components/base/Toast.vue
@@ -75,8 +75,10 @@ const typeConfig: Record<string, { border: string; icon: string; iconColor: stri
           typeConfig[toast.type].border,
         ]"
         role="alert"
+        aria-live="assertive"
         @mouseenter="pauseTimer(toast.id)"
         @mouseleave="resumeTimer(toast.id)"
+        @keydown.escape="onClose(toast.id)"
         @vue:mounted="onToastEnter(toast)"
       >
         <span :class="[typeConfig[toast.type].iconColor, 'text-base leading-none shrink-0']">

--- a/src/components/home/Contact.vue
+++ b/src/components/home/Contact.vue
@@ -28,7 +28,6 @@
           :maxlength="1000"
         />
         <div v-if="error" class="text-tokyo-night-red font-mono">{{ error }}</div>
-        <div v-if="success" class="text-tokyo-night-green font-mono">Message sent successfully!</div>
 
         <BaseButton type="submit" :loading="loading" :disabled="loading">
           Send message
@@ -41,10 +40,10 @@
 <script lang="ts" setup>
 import { ref } from 'vue';
 
+const toast = useToast();
 const form = ref({ name: '', email: '', message: '', subject: '' });
 const loading = ref(false);
 const error = ref<string | null>(null);
-const success = ref(false);
 
 function validateForm() {
   error.value = null;
@@ -69,7 +68,6 @@ async function submitForm() {
   if (!validateForm()) return;
   loading.value = true;
   error.value = null;
-  success.value = false;
 
   try {
     const data = await $fetch<{ status: string; error?: { message: string } }>('/api/contacts', {
@@ -78,14 +76,14 @@ async function submitForm() {
     });
 
     if (data && typeof data === 'object' && 'status' in data && data.status === 'success') {
-      success.value = true;
+      toast.success('Message sent successfully!')
       form.value = { name: '', email: '', message: '', subject: '' };
     } else {
       const msg = data.error?.message || 'Failed to send message';
-      error.value = msg;
+      toast.error(msg)
     }
   } catch (err) {
-    error.value = 'Network error. Please try again.';
+    toast.error('Network error. Please try again.')
   } finally {
     loading.value = false;
   }

--- a/src/composables/useToast.ts
+++ b/src/composables/useToast.ts
@@ -1,0 +1,58 @@
+export interface ToastItem {
+  id: string
+  message: string
+  type: 'success' | 'error' | 'warning' | 'info'
+  duration: number
+}
+
+type ToastType = ToastItem['type']
+
+const DEFAULT_DURATIONS: Record<ToastType, number> = {
+  success: 5000,
+  info: 5000,
+  warning: 0,
+  error: 0,
+}
+
+export function useToast() {
+  const toasts = useState<ToastItem[]>('toasts', () => [])
+
+  function show(options: { message: string; type?: ToastType; duration?: number }): string {
+    const type = options.type ?? 'info'
+    const id = Date.now().toString(36) + Math.random().toString(36).slice(2)
+    const toast: ToastItem = {
+      id,
+      message: options.message,
+      type,
+      duration: options.duration ?? DEFAULT_DURATIONS[type],
+    }
+    toasts.value.push(toast)
+    return id
+  }
+
+  function remove(id: string) {
+    toasts.value = toasts.value.filter((t) => t.id !== id)
+  }
+
+  function clear() {
+    toasts.value = []
+  }
+
+  function success(message: string, duration?: number) {
+    return show({ message, type: 'success', duration })
+  }
+
+  function error(message: string, duration?: number) {
+    return show({ message, type: 'error', duration })
+  }
+
+  function warning(message: string, duration?: number) {
+    return show({ message, type: 'warning', duration })
+  }
+
+  function info(message: string, duration?: number) {
+    return show({ message, type: 'info', duration })
+  }
+
+  return { toasts, show, remove, clear, success, error, warning, info }
+}


### PR DESCRIPTION
## Summary
- Created `useToast` composable with singleton state via `useState` — supports `success()`, `error()`, `warning()`, `info()` shorthands
- Created `BaseToast` component with ARIA live regions (`role="alert"`), auto-dismiss with pause-on-hover/focus, CSS slide transitions
- Mounted `BaseToast` globally in `app.vue`
- Refactored `Contact.vue`: API success/error now use toast notifications, validation errors stay inline

## Accessibility
- Container: `role="region"` + `aria-label="Notifications"`
- Each toast: `role="alert"` (announced by screen readers)
- Close button: `aria-label="Close notification"`, keyboard focusable
- Auto-dismiss pauses on hover and focus

## Test Plan
- [x] Build succeeds
- [x] Non-API pages return 200 (`/about`, `/blog`)
- [ ] Visual: submit contact form → toast appears top-right
- [ ] Toast auto-dismisses after 5s (success/info)
- [ ] Error/warning toasts stay until manually closed
- [ ] Hover pauses auto-dismiss timer

Closes #28