### PR TITLE
🚀 Release 1.0.1

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -54,7 +54,7 @@ jobs:
         id: check_tag
         env:
           TAG: ${{ steps.version.outputs.tag }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
           if gh release view "$TAG" &>/dev/null; then
             echo "::warning::Release $TAG already exists — skipping."
@@ -97,7 +97,7 @@ jobs:
           TAG: ${{ steps.version.outputs.tag }}
           PRERELEASE: ${{ steps.version.outputs.prerelease }}
           MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
           PRERELEASE_FLAG=""
           if [[ "$PRERELEASE" == "true" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.0.1] - 2026-03-19
+
+### Changed
+- Auto-release workflow now uses RELEASE_PAT for GitHub API authentication
+
+---
+
 ## [1.0.0] - 2026-03-19
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-app",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Release 1.0.1

## Changes

### Changed
- Auto-release workflow now uses RELEASE_PAT for GitHub API authentication

## Checklist

- [x] Tests passing
- [x] Lint checks passing
- [x] CHANGELOG.md updated
- [x] Version bumped to 1.0.1

## Reviewers

Please review and approve before merging to main.

> ⚠️ Al mergear, el **auto-release workflow** creará el GitHub Release v1.0.1 automáticamente.
>
> 🚀 El **deploy workflow** debería dispararse automáticamente.