### PR TITLE
🚀 Release 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.0.2] - 2026-03-19
+
+### Changed
+- Updated compose.prod.yml with Traefik labels and external network config
+
+### Fixed
+- Add API environment variables to compose.prod.yml
+
+---
+
 ## [1.0.0] - 2026-03-19
 
 ### Added

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -2,18 +2,27 @@ name: portfolio-prod
 
 services:
   app:
-    image: portfolio:latest
-    build:
-      context: .
-      dockerfile: docker/prod/Dockerfile
-    ports:
-      - '80:3000'
+    image: ${DOCKER_USERNAME:-cativo23}/portfolio-api:latest
+    restart: unless-stopped
     environment:
       NODE_ENV: production
-    restart: unless-stopped
+      NUXT_API_BASE_URL: http://api:3000
+      NUXT_API_BASE_PATH: /api/v1
+      NUXT_API_TOKEN: ${API_TOKEN:-}
+      PORT: 3000
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://localhost:3000').then(r => { if (!r.ok) process.exit(1) }).catch(() => process.exit(1))"]
       interval: 30s
       timeout: 5s
       start_period: 10s
       retries: 3
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.portfolio.rule=Host(`cativo.dev`)"
+      - "traefik.http.routers.portfolio.entrypoints=websecure"
+      - "traefik.http.routers.portfolio.tls.certresolver=letsencryptresolver"
+      - "traefik.http.services.portfolio.loadbalancer.server.port=3000"
+      - "traefik.docker.network=space-server_web"
+networks:
+  space-server_web:
+    external: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-app",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Release 1.0.2

## Changes

### Changed
- Updated compose.prod.yml with Traefik labels and external network config

### Fixed
- Add API environment variables to compose.prod.yml

## Checklist

- [x] Tests passing
- [x] Lint checks passing
- [x] CHANGELOG.md updated
- [x] Version bumped to 1.0.2

## Reviewers

Please review and approve before merging to main.

> ⚠️ Al mergear, el **auto-release workflow** creará el GitHub Release v1.0.2 automáticamente.
>
> 🚀 El **deploy workflow** debería dispararse automáticamente.