### PR TITLE
🐛 fix: disable TypeScript type checking in production

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -25,7 +25,7 @@ export default defineNuxtConfig({
     },
   },
   typescript: {
-    typeCheck: true
+    typeCheck: process.env.NODE_ENV !== 'production'
   },
   content: {
     watch: {


### PR DESCRIPTION
## Description

Disable TypeScript type checking in production to avoid vue-tsc plugin errors.

## Related Issue

Fixes:
```
[Vue] Failed to create plugin TypeError: plugin is not a function
```

## Checklist

- [x] Fix applied to nuxt.config.ts
- [x] Type checking still runs in development

## Reviewers

Please review and merge to develop.