### PR TITLE
🚀 Release 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.0.3] - 2026-03-19
+
+### Fixed
+- Use correct image name 'portfolio' in compose.prod.yml
+
+---
+
 ## [1.0.1] - 2026-03-19
 
 ### Changed

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -2,7 +2,7 @@ name: portfolio-prod
 
 services:
   app:
-    image: ${DOCKER_USERNAME:-cativo23}/portfolio-api:latest
+    image: ${DOCKER_USERNAME:-cativo23}/portfolio:latest
     restart: unless-stopped
     environment:
       NODE_ENV: production

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-app",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Release 1.0.3

## Changes

### Fixed
- Use correct image name 'portfolio' in compose.prod.yml

## Checklist

- [x] Tests passing
- [x] Lint checks passing
- [x] CHANGELOG.md updated
- [x] Version bumped to 1.0.3

## Reviewers

Please review and approve before merging to main.

> ⚠️ Al mergear, el **auto-release workflow** creará el GitHub Release v1.0.3 automáticamente.
>
> 🚀 El **deploy workflow** debería dispararse automáticamente.