### PR TITLE
feat(blog): add 14 new blog posts

### DIFF
--- a/content/blog/configurando-servidor-correo-self-hosted-docker.md
+++ b/content/blog/configurando-servidor-correo-self-hosted-docker.md
@@ -1,0 +1,88 @@
+---
+title: "Configurando un Servidor de Correo Self-Hosted con Docker"
+created_at: 2026-03-26T00:59:00Z
+updated_at: 2026-03-26T00:59:00Z
+image: "/img/blog/alexander-grigoryev-YSEp8dLK8K8-unsplash.jpg"
+author: "Carlos Cativo"
+description: "El proceso completo de configuración de un servidor de email auto-hosteado usando docker-mailserver, Roundcube y Traefik, incluyendo los 30+ commits de prueba y error."
+tags: ["docker", "email", "self-hosting", "traefik", "roundcube"]
+---
+
+Recientemente tomé la decisión de recuperar el control sobre mi infraestructura digital. Uno de los servicios más críticos —y a la vez más intimidantes— de implementar es un servidor de correo electrónico.
+
+Este artículo documenta el proceso **real y completo** de configuración de un servidor de email auto-hosteado usando Docker, Traefik como reverse proxy, y Roundcube como webmail.
+
+## El Desafío
+
+Auto-hostear email tiene fama de ser complicado. Entre SPF, DKIM, DMARC, TLS, y la configuración de Postfix/Dovecot, hay muchas piezas que pueden salir mal.
+
+Mi objetivo era claro:
+- **Correo funcional** con IMAP/SMTP estándar
+- **Webmail moderno** accesible desde cualquier navegador
+- **SSL automático** con Let's Encrypt
+- **Seguro** con SPF, DKIM y DMARC configurados
+- **Mantenible** — que pueda gestionarlo sin dolor
+
+## La Solución
+
+| Componente | Función |
+|------------|---------|
+| docker-mailserver | SMTP/IMAP con OpenDKIM + SpamAssassin |
+| Roundcube | Webmail moderno y familiar |
+| Traefik | Reverse proxy con SSL automático |
+
+## El Viaje: 30+ Commits hasta la Configuración Final
+
+Esta no fue una implementación lineal. Fueron **más de 30 commits** de prueba y error.
+
+### Commit 4: Self-Signed para Interno, Traefik para Público
+
+**Solución clave**: Dejamos que docker-mailserver genere certificados self-signed para la comunicación interna, y Traefik maneja el SSL público para el webmail. Esta fue una decisión arquitectónica importante: **el tráfico entre contenedores es interno y privado**, no necesita Let's Encrypt.
+
+### Commits 5-8: La Saga de Roundcube TLS
+
+Roundcube intentaba conectarse al mail server con TLS, pero como era una red Docker interna, fallaba. Después de múltiples intentos con variables de entorno y archivos de configuración montados, llegamos a la solución: un entrypoint personalizado que escribe la configuración ANTES de que el entrypoint original se ejecute.
+
+### Commits 18-21: Autenticación SMTP
+
+El problema era que Roundcube no podía enviar correos porque la autenticación SMTP no estaba configurada correctamente. La solución fue configurar explícitamente:
+
+```php
+$config['smtp_user'] = '%u';
+$config['smtp_pass'] = '%p';
+$config['smtp_auth_type'] = 'PLAIN';
+$config['smtp_use_tls'] = true;
+$config['smtp_tls_wrapper'] = false;
+```
+
+### Commits 22-24: Escape de Signos de Dólar
+
+En docker-compose.yml, los signos `$` se interpretaban como variables de entorno de shell. La solución: escapar con `$$`.
+
+### Commits 28-29: CSP y Headers de Seguridad
+
+El Content Security Policy (CSP) de Traefik bloqueaba funcionalidades de Roundcube. Creamos un middleware específico para mail sin `frameDeny` y relajamos CSP para Roundcube.
+
+## Lecciones Aprendidas
+
+1. **No expongas puertos innecesarios** — Solo 25, 465, 587, y 993 son esenciales
+2. **Usa volúmenes persistentes** — `mail-data`, `mail-state`, y `mail-logs` deben sobrevivir a recreaciones
+3. **Red interna de Docker** — Roundcube y mail server deben estar en la misma red Docker
+4. **El entrypoint de Roundcube sobrescribe configuración** — Escribir configuración ANTES del entrypoint original
+5. **Escapar signos de dólar en docker-compose** — Usar `$$` en lugar de `$`
+6. **ClamAV consume mucha RAM** — Si tienes menos de 4GB, considera deshabilitarlo
+7. **CSP puede bloquear webmail** — Relajar políticas específicamente para el middleware del mail
+
+## Estado Actual
+
+El servidor está en producción y funcionando correctamente:
+
+- ✅ Envío y recepción de correos
+- ✅ Webmail accesible vía HTTPS
+- ✅ SSL automático con Let's Encrypt para tráfico público
+- ✅ Filtrado de spam activo
+- ✅ Filtros Sieve configurables desde webmail
+- ✅ Autenticación SMTP con STARTTLS
+- ✅ SPF, DKIM, DMARC: PASS
+
+Auto-hostear email es más accesible de lo que parece, pero requiere paciencia. El resultado final es un servidor de correo seguro, funcional y bajo tu control total.

--- a/content/blog/fixing-web-search-bridging-claude-cli-and-qwen-models.md
+++ b/content/blog/fixing-web-search-bridging-claude-cli-and-qwen-models.md
@@ -1,0 +1,106 @@
+---
+title: "Fixing Web Search: Bridging Claude CLI and Qwen Models"
+created_at: 2026-02-02T19:00:00Z
+updated_at: 2026-02-02T19:00:00Z
+image: "/img/blog/alexander-grigoryev-YSEp8dLK8K8-unsplash.jpg"
+author: "Carlos Cativo"
+description: "How I discovered and fixed a tool naming incompatibility between Claude CLI and Qwen models using custom transformer middleware."
+tags: ["ai", "middleware", "debugging", "qwen", "claude-code"]
+---
+
+When integrating the Qwen AI model with Anthropic's Claude Code CLI through the `claude-code-router`, we encountered a frustrating issue: **web search simply didn't work**. While the standalone `qwen` CLI could successfully access web search, the same queries through the `claude` CLI would return:
+
+> "I don't have direct access to web search capabilities..."
+
+Both CLIs were configured to use the same Qwen model through the same router. Why would one work and the other fail?
+
+## The Investigation
+
+### Initial Hypothesis
+
+Our first thought was that this might be a tool availability issue — perhaps the `claude` CLI wasn't exposing the web search tool to the model. However, examining the router logs revealed something interesting: **the `WebSearch` tool was being sent to the Qwen API**, but the model simply wasn't using it.
+
+### Testing Tool Naming Sensitivity
+
+We created test scripts to directly query the Qwen API with different tool naming conventions:
+
+```javascript
+// Test 1: PascalCase (as sent by claude CLI)
+tools: [{ function: { name: "WebSearch" } }]
+
+// Test 2: snake_case (as used by qwen CLI)
+tools: [{ function: { name: "web_search" } }]
+```
+
+**Result**: The Qwen model responded much more reliably when tools were named in `snake_case`. This was our first breakthrough.
+
+### The System Prompt Confusion
+
+Digging deeper, we discovered a second issue: the `claude` CLI identifies itself as "Claude Code" in its system prompt. This created cognitive dissonance for the Qwen model — it was being told it was Claude while actually being Qwen! This confusion likely contributed to the model's reluctance to use its own native capabilities.
+
+## The Root Cause
+
+1. **Tool Naming Convention**: Qwen models are trained to recognize tools in `snake_case` format (`web_search`), while the Claude CLI sends them in `PascalCase` (`WebSearch`).
+2. **System Prompt Identity Crisis**: The Claude CLI's system prompt confused the Qwen model about its own capabilities.
+
+## The Solution: A Custom Transformer
+
+The `claude-code-router` architecture provided the perfect solution through its **transformer system** — middleware that can modify requests before they reach the API and responses before they return to the client.
+
+### Request Transformation
+
+```javascript
+async transformRequestIn(req) {
+    // 1. Rename WebSearch → web_search
+    if (Array.isArray(req.tools)) {
+        req.tools = req.tools.map(tool => {
+            if (tool.function?.name === "WebSearch") {
+                return {
+                    ...tool,
+                    function: { ...tool.function, name: "web_search" }
+                };
+            }
+            return tool;
+        });
+    }
+    // 2. Add helpful reminder to system prompt
+    const reminder = "\n[System Reminder]: You have access to a `web_search` tool.";
+    // Inject into system messages...
+    return req;
+}
+```
+
+### Response Transformation
+
+```javascript
+async transformResponseOut(res) {
+    // Rename web_search → WebSearch (back to Claude's format)
+    if (toolCall.function?.name === "web_search") {
+        toolCall.function.name = "WebSearch";
+    }
+    return transformedResponse;
+}
+```
+
+### Handling Streaming Responses
+
+The transformer needed to handle both standard JSON responses and Server-Sent Events (SSE) streams. For streaming responses, we read chunks, parse SSE data events, detect tool calls in delta messages, rename `web_search` back to `WebSearch`, and re-encode the modified stream.
+
+## Verification
+
+Testing the fix:
+
+```bash
+$ claude -p "give me the latest laravel version"
+```
+
+**Success!** The model now recognizes the `web_search` tool, calls it with appropriate parameters, and returns results with proper citations.
+
+## Key Takeaways
+
+1. **Tool Naming Matters** — Different AI models have different training conventions
+2. **System Prompts Have Power** — The way you describe a model to itself affects its behavior
+3. **Middleware Patterns Work** — The transformer pattern provides a clean way to bridge incompatible systems
+4. **Stream Processing Requires Care** — When working with SSE streams, preserve protocol integrity while modifying content
+
+The fix is now part of version **1.0.3** of the `qwen-claude-setup` project, automatically deployed during installation.

--- a/content/blog/how-i-created-a-free-claude-code-setup-using-qwen-ai.md
+++ b/content/blog/how-i-created-a-free-claude-code-setup-using-qwen-ai.md
@@ -1,0 +1,102 @@
+---
+title: "How I Created a Free Claude Code Setup Using Qwen AI"
+created_at: 2026-02-02T15:00:00Z
+updated_at: 2026-02-02T19:00:00Z
+image: "/img/blog/alexander-grigoryev-YSEp8dLK8K8-unsplash.jpg"
+author: "Carlos Cativo"
+description: "How I routed Claude Code through Qwen's free API using claude-code-router, with multi-distro support and OAuth authentication."
+tags: ["ai", "claude-code", "qwen", "open-source", "linux"]
+---
+
+I love using Claude Code, but like many developers, I was concerned about API costs piling up during daily development. Then I discovered that Qwen AI offers a generous free tier: 2,000 requests per day. The question was: could I use Claude Code's excellent interface with Qwen's free API?
+
+The answer turned out to be yes — with a clever middleware called **claude-code-router**.
+
+## The Discovery: claude-code-router
+
+While researching ways to route Claude Code to different providers, I stumbled upon [`claude-code-router`](https://www.npmjs.com/package/@musistudio/claude-code-router) by [@musistudio](https://github.com/musistudio). This tool acts as a local proxy that sits between the Claude CLI and any OpenAI-compatible API endpoint.
+
+**The architecture is brilliant in its simplicity:**
+
+```
+Claude Code CLI → claude-code-router :3456 → Qwen API → Responses → Claude Code CLI
+```
+
+By setting `ANTHROPIC_BASE_URL` to point to localhost (where the router runs), Claude Code unknowingly sends all its requests to the router, which then forwards them to whatever provider you've configured — in this case, Qwen's API.
+
+## The Challenge: Making It Easy
+
+While the router worked, setting it up manually was tedious and error-prone. I needed to support:
+
+- **Arch Linux**: For my personal development environment
+- **Ubuntu (WSL)**: For my work laptop
+- **Debian and Fedora**: For other developers
+
+### The Setup Requirements
+
+1. Install the right packages for my Linux distribution
+2. Authenticate with Qwen's OAuth system
+3. Extract the OAuth token from JSON files
+4. Generate a proper router configuration
+5. Set up environment variables
+6. Handle platform-specific quirks
+
+## Building the Solution
+
+### Architecture: Modular Shell Scripts
+
+I created a modular structure that separates concerns:
+
+```
+qwen-claude-setup/
+├── install.sh              # Entry point - detects distro
+├── common.sh               # Shared functions used by all distros
+├── distros/
+│   ├── ubuntu.sh
+│   ├── debian.sh
+│   ├── arch.sh
+│   └── fedora.sh
+├── plugins/
+│   └── qwen-transformer.js
+└── scripts/
+    └── uninstall.sh
+```
+
+### OAuth Token Management
+
+Qwen uses OAuth 2.0. The `qwen` CLI handles the authentication flow, storing credentials in `~/.qwen/oauth_creds.json`. My script:
+
+1. Checks if credentials exist
+2. If not, prompts the user to run `qwen` → `/auth` → authenticate in browser
+3. Extracts the `access_token` from the JSON file
+4. Validates the token is present and non-empty
+
+**Security note**: The script sets `chmod 600` on credential files to prevent unauthorized access.
+
+### Environment Variables
+
+```bash
+export ANTHROPIC_BASE_URL="http://127.0.0.1:3456"
+export ANTHROPIC_AUTH_TOKEN="dummy-token"
+export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC="1"
+```
+
+### The Transformer Plugin
+
+The router supports **transformers** — middleware that can modify requests and responses in flight. I created a custom Qwen transformer to solve a critical issue: web search didn't work when using Claude CLI with Qwen.
+
+The problem was that Qwen models expect tools in `snake_case` format (`web_search`), but Claude CLI sends them in `PascalCase` (`WebSearch`). The transformer bridges this gap by renaming tools in both directions.
+
+## Lessons Learned
+
+1. **Heredocs for Configuration** — Using bash heredocs to generate config files is cleaner than string concatenation
+2. **JSON Escaping Matters** — OAuth tokens can contain special characters
+3. **Platform Differences Are Real** — What works on Ubuntu may not work on Arch
+4. **User Experience Is King** — Clear progress messages reduce support burden
+5. **Security By Default** — All credential files set to `chmod 600`
+
+## Conclusion
+
+By combining claude-code-router with Qwen's generous free tier, I created a setup that gives developers a free, production-ready AI coding assistant. The entire setup takes less than 5 minutes and works across major Linux distributions.
+
+All the code is open source at [github.com/cativo23/qwen-claude-setup](https://github.com/cativo23/qwen-claude-setup).

--- a/content/blog/migrating-and-securing-my-space-server-infrastructure.md
+++ b/content/blog/migrating-and-securing-my-space-server-infrastructure.md
@@ -1,0 +1,89 @@
+---
+title: "Migrating and Securing My Space Server Infrastructure"
+created_at: 2026-03-21T12:46:00Z
+updated_at: 2026-03-21T12:46:00Z
+image: "/img/blog/alexander-grigoryev-YSEp8dLK8K8-unsplash.jpg"
+author: "Carlos Cativo"
+description: "A step-by-step account of auditing and hardening my self-hosted Docker server with Traefik, Docker Socket Proxy, and zero-downtime deployment."
+tags: ["traefik", "docker", "security", "infrastructure", "self-hosting"]
+---
+
+Recently, I decided to take a hard look at my personal home server infrastructure (which I call my "space server"). It's a single server running a mix of Docker containers, orchestrated by Traefik as a reverse proxy.
+
+While it was functional, I realized there were several security gaps and best practices I had overlooked during the initial setup. This post details the step-by-step process I took to replicate the infrastructure locally, apply atomic security fixes, and safely deploy the hardened version back to production with zero data loss.
+
+## The Starting Point
+
+My server was running several services via Docker Compose:
+- **Traefik** (v3.6) as the reverse proxy and Let's Encrypt certificate resolver
+- **Grafana & Prometheus** for monitoring
+- **Dozzle** for container logs
+- **Uptime Kuma** for status monitoring
+- Several custom portfolio APIs
+
+### Identifying the Weaknesses
+
+Before making any changes, I audited the existing configuration. Here's what I found:
+
+1. **Exposed Dashboard Port**: Traefik's port `8080` was mapped directly to the host, bypassing secure routing rules
+2. **Exposed Metrics**: Prometheus port `9090` was publicly exposed without authentication
+3. **Hardcoded Credentials**: Grafana was running with default `admin:admin` credentials
+4. **No HTTP to HTTPS Redirect**: Traffic hitting port `80` was not automatically redirected to `443`
+5. **Direct Docker Socket Mounts**: Containers mounting `/var/run/docker.sock` directly — root-equivalent access to the host
+6. **Public Traefik Metrics & Ping**: Internal endpoints exposed on the public entrypoint
+7. **Missing Security Headers**: No HSTS, X-Frame-Options, or XSS protection
+8. **Noisy Logs**: Traefik was set to `DEBUG` log level in production
+
+## The Plan: Atomic Changes
+
+To fix this safely, I pulled the configuration down to my local machine and initialized a Git repository. I then applied each fix as an isolated, atomic commit.
+
+### 1. HTTP to HTTPS Redirection
+
+Updated the Traefik `web` entrypoint to automatically redirect all traffic to HTTPS.
+
+### 2. Closing Exposed Ports
+
+Removed the `8080:8080` port mapping from Traefik and `9090:9090` from Prometheus. Both services are now only accessible via their Traefik subdomains, protected by Let's Encrypt TLS and Basic Authentication.
+
+### 3. Securing Credentials with .env
+
+Replaced hardcoded Grafana credentials with environment variables loaded from a `.env` file (added to `.gitignore`).
+
+### 4. Isolating Internal Endpoints
+
+Created dedicated internal entrypoints for Traefik's metrics and health check (ping) — no longer public.
+
+### 5. Implementing Security Headers
+
+Added a `security-headers` middleware in Traefik's dynamic configuration to enforce HSTS, prevent clickjacking, and enable XSS filtering.
+
+### 6. The Crown Jewel: Docker Socket Proxy
+
+Mounting the Docker socket directly is dangerous. To fix this, I introduced [Tecnativa's Docker Socket Proxy](https://github.com/Tecnativa/docker-socket-proxy).
+
+It acts as a firewall for the Docker API. I configured it to only allow read-only access to specific endpoints (containers, networks, services, swarm, tasks). Then updated Traefik and Dozzle to connect to the proxy via TCP instead of mounting the socket.
+
+## The Deployment Strategy
+
+Deploying these changes to production required care to avoid downtime or losing Let's Encrypt certificates and Grafana data.
+
+1. **Full Backup** — Created a complete backup of the existing directory on the server
+2. **Spin Down** — Ran `docker compose down` for all stacks
+3. **Preserve State** — Moved `acme.json` to a safe location outside the project directory
+4. **Replace Code** — Transferred the new, hardened configuration via `scp`
+5. **Restore State** — Moved `acme.json` back with correct permissions (`600`)
+6. **Secret Injection** — Created the `.env` file on the server with production secrets
+7. **Spin Up** — Ran `docker compose up -d` across all stacks
+
+### A Small Hiccup with Docker Bind Mounts
+
+During the deployment, I ran into an interesting edge case. After fixing a typo in my `.env` and transferring updated files via `scp`, Traefik was serving its default self-signed certificate instead of my Let's Encrypt cert.
+
+**The Root Cause**: When I ran `scp -r` the second time, it overwrote the host directory. However, the Traefik container was already running and had a bind mount to the *inode* of the original directory. When the host directory was replaced, the container's mount became detached.
+
+**The Fix**: A simple `docker restart traefik` forced the container to remount the path using the new inode.
+
+## Conclusion
+
+With these changes, my space server is now significantly more secure. The attack surface is reduced, traffic is encrypted by default, the Docker daemon is protected by a proxy, and the infrastructure is now version-controlled with a clean Git history.

--- a/content/blog/migrating-to-qwen-claude-cli-and-quotas.md
+++ b/content/blog/migrating-to-qwen-claude-cli-and-quotas.md
@@ -1,0 +1,68 @@
+---
+title: "Migrating to qwen-claude CLI & Navigating Qwen Quota Changes"
+created_at: 2026-02-08T16:18:00Z
+updated_at: 2026-02-08T16:18:00Z
+image: "/img/blog/alexander-grigoryev-YSEp8dLK8K8-unsplash.jpg"
+author: "Carlos Cativo"
+description: "How we refactored setup scripts into a professional CLI tool and dealt with Qwen's free tier quota reduction."
+tags: ["cli", "qwen", "ai", "open-source", "quotas"]
+---
+
+We completely refactored the setup scripts into a professional CLI tool: `qwen-claude`.
+
+## Why a CLI?
+
+Managing multiple scripts (`install.sh`, `refresh.sh`, distro-specific scripts) was becoming cumbersome. The new `qwen-claude` tool unifies everything into a single command:
+
+```bash
+qwen-claude install   # Setup everything
+qwen-claude refresh   # Update OAuth tokens & restart services
+qwen-claude help      # Show usage
+```
+
+## The Qwen Quota "Nerf"
+
+Recently, it seems Qwen has reduced the free tier limit significantly. Users (including myself) have started seeing `insufficient_quota` errors much faster than before.
+
+> **Update:** The free quota has been officially reduced from 2,000 to **1,000 requests per day**.
+
+### Symptoms
+
+If you are using `portal.qwen.ai` (Bearer Token) and suddenly see this:
+
+```json
+{
+  "error": {
+    "code": "insufficient_quota",
+    "message": "Free allocated quota exceeded.",
+    "type": "invalid_request_error"
+  }
+}
+```
+
+It means you've hit the daily cap.
+
+### Alternatives
+
+1. **Alibaba Model Studio (Free Tier)** — Generous free tier for new users (valid for 60-90 days)
+2. **Paid API Key** — The paid API via `dashscope-intl.aliyuncs.com` is more stable with higher rate limits
+
+## CLI Feature: Auto-Refresh
+
+We added a `refresh` command to make life easier with these shorter-lived tokens:
+
+```bash
+qwen-claude refresh
+```
+
+This will:
+1. Guide you to refresh your OAuth token
+2. Update the configuration automatically
+3. Restart the `claude-code-router` service
+
+## Troubleshooting Updates
+
+- **Fixed `install` command**: Corrected argument parsing
+- **Fixed `setup.sh`**: Restored missing variable definitions
+- **Automated Restart**: The tool now automatically restarts the router after installation and refreshes
+- **Shifted Recommendation**: We now recommend the **Bearer Token (OAuth)** for personal use — 1,000 requests/day that **resets every day**

--- a/content/blog/nova-id-day-1-starting-the-journey.md
+++ b/content/blog/nova-id-day-1-starting-the-journey.md
@@ -1,0 +1,48 @@
+---
+title: "Nova ID - Day 1: Starting the Zero Trust Journey"
+created_at: 2026-01-15T09:00:00Z
+updated_at: 2026-01-15T21:00:00Z
+image: "/img/blog/alexander-grigoryev-YSEp8dLK8K8-unsplash.jpg"
+author: "Carlos Cativo"
+description: "Day 1 of building Nova ID — a Zero Trust identity system using the Ory Stack. Architecture decisions, why Zero Trust, and initial planning."
+tags: ["zero-trust", "ory", "identity", "architecture", "nova-id"]
+---
+
+We're building an identity system. Not just any identity system — a **Zero Trust** identity system. Why? Because traditional security models are broken.
+
+## What We're Building
+
+Nova ID — a complete identity and access management system using the Ory Stack. The goal is to have something production-ready that demonstrates how to do identity management right.
+
+## Why Zero Trust?
+
+I've seen too many systems where once you're inside the network, you have access to everything. That's a security nightmare. Zero Trust says "never trust, always verify" — and that's exactly what we need.
+
+The idea is simple: every request goes through a gateway (Oathkeeper), gets authenticated, and then gets routed to the right service with identity headers. No service-to-service trust. Everything is verified.
+
+## Choosing the Stack
+
+We're going with the **Ory Stack**:
+- **Kratos** for identity management
+- **Hydra** for OAuth2/OIDC
+- **Keto** for permissions
+- **Oathkeeper** as the gateway
+
+Why Ory? It's open source, well-documented, and used in production by real companies. Plus, it's composable — we can use what we need.
+
+## The Pattern: Identity-Aware Proxy
+
+```
+User → Oathkeeper (authenticates) → Backend Service (gets identity via headers)
+```
+
+Backend services never authenticate directly. They just trust the headers that Oathkeeper injects.
+
+## What I'm Worried About
+
+1. **Path stripping** — How do we handle routing through Oathkeeper?
+2. **CORS** — This is always a pain
+3. **Email delivery** — Need to test this somehow
+4. **Permissions** — How do we design a good RBAC system?
+
+But hey, that's why we're building this — to figure it out.

--- a/content/blog/nova-id-day-16-looking-forward.md
+++ b/content/blog/nova-id-day-16-looking-forward.md
@@ -1,0 +1,54 @@
+---
+title: "Nova ID - Day 16: Looking Forward"
+created_at: 2026-01-30T09:00:00Z
+updated_at: 2026-01-30T21:00:00Z
+image: "/img/blog/alexander-grigoryev-YSEp8dLK8K8-unsplash.jpg"
+author: "Carlos Cativo"
+description: "Day 16 of Nova ID — Production readiness assessment, roadmap, reflections on what we built and what's missing."
+tags: ["retrospective", "roadmap", "zero-trust", "nova-id"]
+---
+
+We have a working Zero Trust identity system:
+
+- Identity management (Kratos)
+- OAuth2/OIDC provider (Hydra)
+- Fine-grained permissions (Keto)
+- API gateway (Oathkeeper)
+- Modern frontend (Vue 3)
+- RBAC with automatic permission resolution
+- Professional UI with permission-based features
+
+This is solid. It works. But is it production-ready?
+
+## What's Missing
+
+**Critical**: HTTPS/TLS, production database, production email service, secrets management, security headers, monitoring and logging.
+
+**Important**: Backend API layer (frontend calls Ory services directly), rate limiting, session management improvements, backup and disaster recovery, performance optimization.
+
+**Nice to Have**: MFA, social login, audit logging, user self-service features.
+
+## The Reality Check
+
+We built this for local development. It's not production-ready yet. But the architecture is solid. The foundation is there.
+
+**What We Did Right**: Zero Trust architecture from the start, proper service isolation, RBAC with subject sets, clean separation of concerns.
+
+**What Needs Work**: Security hardening, performance optimization, production deployment, feature completeness.
+
+## Reflections
+
+### What I Learned
+
+1. **Zero Trust is the right approach** — It's more work upfront, but it's more secure
+2. **Subject sets are powerful** — Automatic permission resolution is a game-changer
+3. **CORS is still annoying** — But manageable if you understand it
+4. **Documentation matters** — Writing this diary helped me understand what we built
+5. **Problems are opportunities** — Every bug taught us something
+
+### What I'd Do Differently
+
+1. **Start with backend API layer** — Frontend calling Ory services directly works, but a backend layer would be cleaner
+2. **More testing earlier** — We should have written tests as we went
+3. **Better error handling** — Some error messages could be clearer
+4. **Performance from the start** — We focused on functionality, but performance matters too

--- a/content/blog/nova-id-day-17-architecture-refactor.md
+++ b/content/blog/nova-id-day-17-architecture-refactor.md
@@ -1,0 +1,53 @@
+---
+title: "Nova ID - Day 17: Architecture Refactor - Three Frontends, Zero Trust"
+created_at: 2026-01-31T09:00:00Z
+updated_at: 2026-01-31T21:00:00Z
+image: "/img/blog/alexander-grigoryev-YSEp8dLK8K8-unsplash.jpg"
+author: "Carlos Cativo"
+description: "Day 17 of Nova ID — Refactoring from a single monolithic frontend to three separate frontend applications matching the ideal Zero Trust pattern."
+tags: ["architecture", "zero-trust", "refactoring", "vue", "nova-id"]
+---
+
+Today we refactored the architecture to match the ideal Zero Trust pattern with **three separate frontend applications** instead of a single monolithic frontend.
+
+## What Changed
+
+### Before: Single Frontend
+- One Vue.js application handling all functionality
+- Mixed concerns: authentication, admin, and business logic in one app
+- All routes accessible from a single entry point
+
+### After: Three Separate Frontends
+
+**Frontend #1: Self-Service UI** (Port 5173) — Authentication flows: login, registration, password recovery, profile settings, OAuth consent.
+
+**Frontend #2: Admin Dashboard** (Port 5174) — User management, permission management, dashboard with session information, permission-based access control.
+
+**Frontend #3: Test Application** (Port 5175) — Main business application with API integration.
+
+## Oathkeeper Routing
+
+Oathkeeper now routes requests based on path prefixes:
+
+- `/auth/*` → `frontend-auth:5173` (Self-Service UI)
+- `/admin/*` → `frontend-admin:5174` (Admin Dashboard)
+- `/app/*` → `frontend-app:5175` (Test Application)
+- `/api/*` → `api:8080` (Test API)
+
+All routes go through Oathkeeper, which authenticates, authorizes, injects user context headers, and routes to the appropriate backend service.
+
+## Benefits
+
+1. **Separation of Concerns** — Authentication UI separate from admin functions, business logic isolated from management tools
+2. **Security** — Admin dashboard requires authentication + permissions, each frontend has minimal surface area
+3. **Scalability** — Can deploy frontends independently, different scaling requirements per frontend
+4. **Development** — Teams can work on different frontends independently
+5. **Zero Trust Compliance** — All traffic flows through Oathkeeper, no direct access to backend services
+
+## Lessons Learned
+
+1. **Architecture First** — Having a clear architecture diagram helped guide the refactor
+2. **Incremental Changes** — Breaking it into three separate tasks made it manageable
+3. **Shared Code** — Copying composables to each frontend works, but consider a shared package in the future
+4. **Routing** — Oathkeeper path-based routing is clean and works well
+5. **Port Management** — Using different ports for each frontend avoids conflicts

--- a/content/blog/nova-id-day-18-ory-stack-integration.md
+++ b/content/blog/nova-id-day-18-ory-stack-integration.md
@@ -1,0 +1,76 @@
+---
+title: "Nova ID - Day 18: Full Ory Stack Integration - Zero Trust API"
+created_at: 2026-02-01T09:00:00Z
+updated_at: 2026-02-01T21:00:00Z
+image: "/img/blog/alexander-grigoryev-YSEp8dLK8K8-unsplash.jpg"
+author: "Carlos Cativo"
+description: "Day 18 of Nova ID — Replaced dummy API with a NestJS API that actively consumes Ory services through Oathkeeper only, proving Zero Trust actually works."
+tags: ["nestjs", "zero-trust", "ory", "api", "nova-id"]
+---
+
+Today we replaced the dummy Python API with a **production-ready NestJS API** that **actively consumes** Ory services (Kratos, Keto, Hydra) through **Oathkeeper only** (Zero Trust). The API is on an **external network** and **cannot directly access** Ory services.
+
+## Architecture (Zero Trust)
+
+```
+External Network: Frontends + API (cannot access Ory services directly)
+                        ↓
+                Oathkeeper (gateway, both networks)
+                        ↓
+Ory Stack Network (Private): Kratos, Keto, Hydra, PostgreSQL
+```
+
+**Key**: API CANNOT directly reach Kratos, Keto, or Hydra.
+
+## Ory Service Integration
+
+### Kratos Integration
+- API verifies user exists and is active via **Oathkeeper → Kratos**
+- Retrieves full identity from Kratos Admin API via **Oathkeeper**
+- API physically cannot reach Kratos directly (different network)
+
+### Keto Integration
+- API checks rank membership via **Oathkeeper → Keto**
+- Verifies rank hierarchy via **Oathkeeper**
+- Real-time permission queries via **Oathkeeper**
+
+### Hydra Integration
+- API introspects OAuth2 access tokens via **Oathkeeper → Hydra**
+- Validates token expiration via **Oathkeeper**
+- Supports client credentials grant (API keys)
+
+## Authentication Methods
+
+### Session-Based (Web Frontends)
+1. User logs in → Kratos creates session
+2. Frontend makes request → Oathkeeper validates session
+3. Oathkeeper injects headers → API receives request
+4. API verifies user in Kratos via Oathkeeper
+5. API checks permissions in Keto via Oathkeeper
+
+### OAuth2 Token-Based (Third-Party Apps)
+1. Third-party app gets token → Hydra issues token
+2. App makes request with Bearer token
+3. API introspects token in Hydra via Oathkeeper
+4. API verifies user in Kratos via Oathkeeper
+5. API checks permissions in Keto via Oathkeeper
+
+## Zero Trust Verification
+
+To verify Zero Trust is working:
+
+```bash
+# Test Direct Access (Should Fail)
+docker exec nova-id-api-1 ping kratos
+# Should fail - different networks
+
+# Test Through Oathkeeper (Should Work)
+docker exec nova-id-api-1 wget -O- http://oathkeeper:4455/health/alive
+# Should work - same network
+```
+
+## Conclusion
+
+Every request verifies users in Kratos via Oathkeeper (cannot reach directly), checks permissions in Keto via Oathkeeper (cannot reach directly), and supports OAuth2 tokens via Hydra via Oathkeeper (cannot reach directly).
+
+**This proves Zero Trust works** — API is on external network and cannot directly access Ory services.

--- a/content/blog/nova-id-day-2-3-setting-up-infrastructure.md
+++ b/content/blog/nova-id-day-2-3-setting-up-infrastructure.md
@@ -1,0 +1,74 @@
+---
+title: "Nova ID - Day 2-3: Setting Up the Infrastructure"
+created_at: 2026-01-16T09:00:00Z
+updated_at: 2026-01-17T21:00:00Z
+image: "/img/blog/alexander-grigoryev-YSEp8dLK8K8-unsplash.jpg"
+author: "Carlos Cativo"
+description: "Day 2-3 of Nova ID — Docker Compose setup, database initialization, SMTP configuration, CORS headaches, and the first real challenges with Ory Stack."
+tags: ["docker", "ory", "infrastructure", "nova-id", "debugging"]
+---
+
+Started with Docker Compose. Should be simple, right? Wrong.
+
+## Docker Compose Hell
+
+### Service Communication
+
+I wanted services to communicate via Docker hostnames (`http://kratos:4433`), not localhost. This enforces Zero Trust — services can't be accessed directly from the host.
+
+**Solution**: Oathkeeper routes to internal Docker hostnames. The gateway is the only thing exposed to the host. Everything else is internal.
+
+### Database Initialization
+
+Three separate databases:
+- `kratos` for identity
+- `hydra` for OAuth
+- `keto` for permissions
+
+**Why separate?** Isolation. If one service has issues, it doesn't affect the others. Plus, we can scale them independently.
+
+### The Courier Worker Problem
+
+Emails weren't sending. No errors, but no activity either.
+
+**Discovery**: Kratos has a separate courier worker process. You need to run it with `--watch-courier` flag!
+
+```yaml
+command: serve -c /etc/config/kratos/kratos.config.yaml --dev --watch-courier
+```
+
+### The STARTTLS Problem
+
+Mailpit doesn't support STARTTLS. The fix:
+
+```yaml
+courier:
+  smtp:
+    connection_uri: smtp://mailpit:1025/?disable_starttls=true
+```
+
+### The CORS Problem
+
+Keto has CORS configuration. But in Zero Trust, only the gateway should handle CORS. Backend services shouldn't send CORS headers.
+
+**Solution**: Remove the entire `cors:` section from the config. If the section doesn't exist, Keto won't send CORS headers.
+
+### The Path Stripping Discovery
+
+I was worried about path stripping. Oathkeeper needs to route `/kratos-public/self-service/login/api` to Kratos, but Kratos expects `/self-service/login/api`.
+
+**Discovery**: Oathkeeper DOES support `strip_path` in access rules! No proxy services needed.
+
+```yaml
+- id: "keto-read"
+  upstream:
+    strip_path: "/keto/read"
+    url: "http://keto:4466"
+```
+
+## What I Learned
+
+1. Always check if a feature exists before building a workaround
+2. CORS is still a pain, even in 2026
+3. Email configuration is more complex than it should be
+4. Docker Compose dependency management is clunky but works

--- a/content/blog/nova-id-day-4-5-building-authorization-system.md
+++ b/content/blog/nova-id-day-4-5-building-authorization-system.md
@@ -1,0 +1,68 @@
+---
+title: "Nova ID - Day 4-5: Building the Authorization System"
+created_at: 2026-01-18T09:00:00Z
+updated_at: 2026-01-19T21:00:00Z
+image: "/img/blog/alexander-grigoryev-YSEp8dLK8K8-unsplash.jpg"
+author: "Carlos Cativo"
+description: "Day 4-5 of Nova ID — Implementing RBAC with Ory Keto subject sets, the 403 permission check problem, and automatic rank synchronization."
+tags: ["rbac", "keto", "permissions", "zero-trust", "nova-id"]
+---
+
+We need a Role-Based Access Control system. I decided to use a military-style rank hierarchy: General, Colonel, Major, Captain, Lieutenant, Sergeant, Corporal, Private.
+
+## Discovering Keto Subject Sets
+
+Instead of granting permissions directly to users:
+```
+users:management#view_users@user:123
+users:management#add_users@user:123
+... (many more)
+```
+
+You grant permissions to roles, and then assign users to roles:
+```
+users:management#view_users@rank:General#member
+rank:General#member@user:123
+```
+
+**The Magic**: When you check if `user:123` can `view_users`, Keto automatically resolves the chain. Change a user's rank, and all their permissions update automatically.
+
+**Before**: Change rank = update 10+ permission tuples
+**After**: Change rank = update 1 membership tuple
+
+## The 403 Problem
+
+Frontend was checking permissions, but getting 403 errors. Treated them as failures.
+
+**Problem**: Keto returns HTTP 403 with `{"allowed": false}` for denied permissions. This is a **valid** response, not an error!
+
+**Solution**: Parse the JSON response even on 403 status:
+
+```javascript
+const response = await fetch(url)
+const data = await response.json() // Works even on 403
+
+if (data.hasOwnProperty('allowed')) {
+  return data.allowed === true // Valid permission check
+}
+```
+
+## The Caching Decision
+
+I initially cached permission checks for 5 minutes. But then I realized: what if a user's rank changes? The UI would show wrong permissions for 5 minutes.
+
+**Decision**: Remove caching. Make all checks real-time. For admin operations, accuracy is more important than performance.
+
+## The General User Problem
+
+"General user can't manage users." The user had `rank: "General"` in Kratos, but wasn't assigned to `rank:General` in Keto.
+
+**Solution**: Created `syncRankPermissions()` function that removes from old rank and assigns to new rank, called automatically when creating or updating users.
+
+## What I Learned
+
+1. Subject sets are powerful — use them
+2. 403 responses can be valid (not errors)
+3. Caching permissions is risky — prefer accuracy
+4. Always sync rank membership when rank changes
+5. Diagnostic tools are essential

--- a/content/blog/nova-id-day-6-8-frontend-development.md
+++ b/content/blog/nova-id-day-6-8-frontend-development.md
@@ -1,0 +1,68 @@
+---
+title: "Nova ID - Day 6-8: Frontend Development"
+created_at: 2026-01-20T09:00:00Z
+updated_at: 2026-01-22T21:00:00Z
+image: "/img/blog/alexander-grigoryev-YSEp8dLK8K8-unsplash.jpg"
+author: "Carlos Cativo"
+description: "Day 6-8 of Nova ID — Vue 3 setup, working with Kratos UI nodes, password validation, and the form field clearing nightmare."
+tags: ["vue", "frontend", "kratos", "nova-id", "debugging"]
+---
+
+Vue 3 + Vite. Should be straightforward, right?
+
+## The Setup
+
+Vite is fast. The dev server starts instantly. HMR works perfectly. Spent some time configuring Tailwind with Tokyo Night colors — dark background, high contrast, easy on the eyes.
+
+## Working with Kratos UI Nodes
+
+Kratos returns forms as "UI nodes" — structured JSON that describes form fields. This is actually pretty cool — we can render forms dynamically without hardcoding.
+
+But it's also annoying. The structure is complex, and we need utility functions to extract values.
+
+Created helper functions: `getNodeName()`, `getNodeType()`, `getNodeValue()`, `getNodeLabel()`, etc. These make working with UI nodes bearable.
+
+## The Password Validation Requirement
+
+Users wanted:
+- Password confirmation field
+- Real-time validation (length, uppercase, lowercase, number, special char)
+- Visual checklist
+- Checkmark when passwords match
+
+Created computed properties for password rules and match checking. Users get immediate feedback.
+
+## The Form Field Clearing Nightmare
+
+When typing in password fields, other form fields (email, name, rank) were being cleared. This was infuriating.
+
+**Root Cause**: Vue was re-rendering the form when `node.attributes.value` changed. Password input triggered a re-render, which reset other fields that weren't properly bound to reactive state.
+
+**Solution**: Store all field values in a reactive object:
+
+```javascript
+const fieldValues = reactive({})
+
+onMounted(() => {
+  flow.value?.ui?.nodes?.forEach(node => {
+    const name = getNodeName(node)
+    fieldValues[name] = getNodeValue(node) || ''
+  })
+})
+```
+
+**Key Insight**: Separate form state from Kratos flow nodes. The nodes are for submission, but the form state is for the UI.
+
+## The Password Visibility Toggle Problem
+
+Clicking the eye icon to toggle password visibility cleared the password value. Vue re-rendered the input when the `type` attribute changed from `password` to `text`.
+
+**Solution**: Store password value in a ref and bind the input to it instead of `getNodeValue(node)`.
+
+## What I Learned
+
+1. Kratos UI nodes are powerful but verbose
+2. Vue reactivity requires careful state management
+3. Form state should be separate from Kratos nodes
+4. Real-time validation improves UX significantly
+5. Small UI details matter

--- a/content/blog/nova-id-day-9-15-problem-solving-marathon.md
+++ b/content/blog/nova-id-day-9-15-problem-solving-marathon.md
@@ -1,0 +1,87 @@
+---
+title: "Nova ID - Day 9-15: The Problem-Solving Marathon"
+created_at: 2026-01-23T09:00:00Z
+updated_at: 2026-01-29T23:00:00Z
+image: "/img/blog/alexander-grigoryev-YSEp8dLK8K8-unsplash.jpg"
+author: "Carlos Cativo"
+description: "Day 9-15 of Nova ID — Email delivery saga, CSRF nightmare, password reset bugs, permission check issues, and CORS conflicts."
+tags: ["debugging", "zero-trust", "ory", "nova-id", "lessons-learned"]
+---
+
+This was a marathon. So many problems, but we solved them all.
+
+## Day 10: The Email Delivery Saga
+
+Emails weren't being sent. Users couldn't recover passwords.
+
+1. **First fix**: Added `--watch-courier` flag to Kratos
+2. **Second fix**: Added `?disable_starttls=true` to SMTP URI
+3. **Discovery**: Kratos doesn't send recovery emails for non-existent addresses (anti-enumeration security feature)
+
+**Test**: Used an existing user. Email sent!
+
+## Day 11: The CSRF Nightmare
+
+Mixing API and browser flows caused CSRF errors. Kratos has two types of flows:
+- **Browser flows**: `/self-service/login/browser` — for web apps
+- **API flows**: `/self-service/login/api` — for mobile apps, programmatic access
+
+You can't mix them. Browser flows handle CSRF automatically. API flows don't.
+
+## Day 12: The Password Reset That Didn't Reset
+
+"Changed my password, but I can't log in with the new one. Old password still works."
+
+**Root Cause**: We were sending profile fields (email, name, rank) along with password fields. Kratos determines the flow type based on which fields are present.
+
+**Fix**: Only send password-related fields:
+
+```javascript
+const passwordFormData = new FormData()
+passwordFormData.set('method', 'password')
+passwordFormData.set('password', passwordValue.value)
+passwordFormData.set('password_confirm', passwordConfirm.value)
+passwordFormData.set('csrf_token', csrfToken)
+// Don't include profile fields!
+```
+
+## Day 13: The Permission Check 403 Problem
+
+Keto returns HTTP 403 with `{"allowed": false}` for denied permissions. Parse the JSON and check the `allowed` field.
+
+## Day 14: The General User Access Denied
+
+User had `rank: "General"` in Kratos, but wasn't assigned to `rank:General` in Keto. Created `syncRankPermissions()` to fix this automatically.
+
+## Day 15: The Keto Direct Access Security Issue
+
+Frontend was directly accessing Keto APIs. This violates Zero Trust! Routed all Keto requests through Oathkeeper.
+
+## The CORS Conflict
+
+After routing Keto through Oathkeeper, we got CORS errors. Keto was STILL sending CORS headers even with the section removed.
+
+**Solution**: Remove the entire `cors:` section completely, not just set `enabled: false`.
+
+## The OPTIONS Method Error
+
+Oathkeeper doesn't allow `OPTIONS` in `allowed_methods`. But it handles OPTIONS automatically when CORS is enabled. Remove it from the list.
+
+## The Unnecessary Preflight
+
+GET requests were triggering CORS preflight because the frontend was sending `Content-Type: application/json`. GET requests don't need it.
+
+**Fix**: Remove `Content-Type` header from GET requests.
+
+## Problems Solved
+
+- Path stripping (Oathkeeper handles it)
+- Email delivery (courier worker + STARTTLS)
+- CSRF (browser vs API flows)
+- Password reset (method field)
+- Permission checks (403 parsing)
+- Rank sync (automatic sync function)
+- Keto security (route through Oathkeeper)
+- CORS conflicts (remove from backend)
+- OPTIONS method (automatic handling)
+- Unnecessary preflight (remove Content-Type)

--- a/content/blog/one-partition-to-rule-them-all.md
+++ b/content/blog/one-partition-to-rule-them-all.md
@@ -1,0 +1,195 @@
+---
+title: "One Partition to Rule Them All: The Sequel Nobody Asked For"
+created_at: 2026-04-14T00:00:00Z
+updated_at: 2026-04-14T00:00:00Z
+image: "/img/blog/alexander-grigoryev-YSEp8dLK8K8-unsplash.jpg"
+author: "Carlos Cativo"
+description: "A month after migrating root to a 45G partition, it filled up again. So I deleted it entirely and merged everything into one 477G disk. Twenty-four AI agents reviewed the script before I ran it. The disks swapped names again."
+tags: ["arch-linux", "sysadmin", "claude-code", "nvme", "partitions"]
+---
+
+A month after the last migration, I ran `df -h` and laughed. Not the good kind.
+
+```
+/dev/nvme0n1p2   44G   38G   4.1G  91% /
+/dev/nvme0n1p1  432G   89G  321G  22% /home
+```
+
+Ninety-one percent. Four gigs free. The same feeling as last time — a large disk sitting mostly empty while root chokes on its own organs. Except this time I had 44 gigabytes, not 26. I'd moved Docker to /home. I'd enabled paccache.timer. I'd capped journald at 200 megs. I'd done everything right, and root was full anyway, because 44 gigabytes is not a root partition — it's a grace period.
+
+Flatpaks. That's what killed it this time. Flatpak stores everything in `/var/lib/flatpak`, which lives on root, because of course it does. Each app pulls its own runtime — a frozen slice of GNOME or KDE or freedesktop.org, duplicated per application because isolation is more important than your disk space. Install five apps, get three copies of `org.gnome.Platform`. Each one weighs a gigabyte. Flatpak doesn't ask. It doesn't warn. It just fills your root like water filling a basement.
+
+I could have moved Flatpak to /home too. Symlink `/var/lib/flatpak` to `/home/flatpak`, the same trick I'd used for Docker. But I was running out of things to relocate. Docker on /home. Flatpak on /home. Pacman cache on /home. At some point you're not managing a partition — you're managing an elaborate system of redirects that exists solely because you drew the wrong line on a disk five months ago.
+
+The two-partition layout was the problem. Not Docker, not Flatpak, not systemd's logging habits. The problem was that I had 477 gigabytes and I'd split them into a place where things live and a place where things work, and the place where things work was always too small, and the place where things live was always too empty. Two partitions on a single-user laptop is a solution to a problem I don't have.
+
+So I decided to delete the partition.
+
+---
+
+## The Plan (Again)
+
+The layout I had:
+
+```
+nvme0n1     476.9G
+├─nvme0n1p1   432G ext4   /home
+└─nvme0n1p2  44.9G ext4   /
+
+nvme1n1      27.3G
+├─nvme1n1p1     1G vfat   /boot
+└─nvme1n1p2  26.2G ext4   (old root backup from last time)
+```
+
+The layout I wanted:
+
+```
+nvme0n1     476.9G
+└─nvme0n1p1 476.9G ext4   /       ← everything
+
+nvme1n1      27.3G
+├─nvme1n1p1     1G vfat   /boot
+└─nvme1n1p2  26.2G ext4   (can be wiped later)
+```
+
+One partition. Root and home together. No more capacity planning, no more symlink gymnastics, no more watching 300 gigs sit idle while `pacman -Syu` fails because `/var` is full. Just one big ext4 with everything on it, the way a single-user system should have been from the start.
+
+The catch: nvme0n1p1 was /home. nvme0n1p2 was root. I couldn't just delete p2 and call it done — root's files had to end up on p1. And I couldn't resize p1 while p2 existed next to it on the same disk, because GPT partitions can only grow into adjacent free space, and p2 was in the way.
+
+So: back up root to nvme1n1p2 (the 26G spare partition that still had the old backup from last time — ironic), delete nvme0n1p2, grow nvme0n1p1 from 432G to 477G, copy root files from the backup into the now-merged partition. Update fstab. Reinstall GRUB. Pray.
+
+Same recipe as last time. Except this time, the data I cared about — /home — was on the partition I was *resizing*. Last time, /home was untouched. This time, one wrong flag to `parted` and my entire home directory would be reformatted into a blank ext4. The margin for error went from "you'll have to reinstall" to "you'll lose everything."
+
+I was not doing this by hand.
+
+---
+
+## Two Scripts, Twenty-Four Agents
+
+Last time, Claude wrote one script and I ran it after one round of review. It worked — barely — after three boots and a USB stick I found in a drawer. This time I wanted something more disciplined. I was older. Wiser. Marginally less reckless.
+
+I asked Claude Code for two scripts: `backup.sh` to run on the live system, and `automigrate.sh` to run from a live USB. Separation of concerns — the backup happens while everything is stable and mounted, the dangerous work happens when nothing is mounted and nothing can go wrong except everything.
+
+`backup.sh` was straightforward. Verify disk layout, check sizes, format the spare 26G partition, `rsync` everything on `/` to it, save metadata, write a sentinel file (`.backup-complete`) so the migration script can verify the backup finished. The sentinel matters because `rsync` can be interrupted — if you kill it mid-copy and the migration script trusts the partial backup, you'll restore a root filesystem missing half of `/usr/lib`. The sentinel is a timestamp written after rsync and verification both pass. No sentinel, no migration.
+
+`automigrate.sh` was the scary one. 470 lines of bash that deletes a partition, resizes another one while your data is on it, copies a root filesystem, writes an fstab, installs GRUB from inside a chroot, and verifies every UUID in the chain from BIOS to kernel. The kind of script where a misplaced `mkfs` or a wrong device path means you're restoring from backups — assuming you have backups, assuming the backup script didn't also have bugs.
+
+So I didn't run it after one round of review. I ran six.
+
+Each round dispatched three to four specialized agents in parallel — not the same generic "check for bugs" request, but focused roles. A code reviewer looking for logic errors and crashes. A chaos engineer imagining power failures, partial writes, killed processes. A dry-run simulator mentally executing every line with the actual disk layout. An Arch Linux boot specialist verifying the GRUB/fstab/mkinitcpio chain. A variable tracer following every `$HOME_PART` and `$NEW_UUID` through every conditional branch.
+
+Twenty-four agents across six rounds. Each round focused on what the previous round missed, not on re-reporting fixed issues. By round four, the format was GO/NO-GO — only critical and high severity, skip the medium and low. By round six, all four agents returned GO independently.
+
+They found ten bugs across those rounds. Some were cosmetic. Some would have killed my system.
+
+---
+
+## The Bugs That Would Have Killed It
+
+The first draft used `sgdisk` to delete partition 2, then used `sgdisk` again to recreate partition 1 at a larger size. Delete and recreate. The problem: between the delete and the recreate, the partition table has no entry for partition 1. If the power goes out — if the kernel panics, if someone trips over the power cord, if the battery dies because you forgot to plug in the laptop — the disk has zero partitions. Your /home data is still on the raw blocks, but the partition table doesn't know that. You'd need a partition recovery tool and a lot of patience.
+
+The fix was `parted resizepart 1 100%` — a single atomic operation that grows the partition in place. No delete step. No window where the partition entry is missing. The data on p1 never moves, because ext4 block addresses are relative to the partition start, and the start doesn't change. Only the end moves. `parted` updates the GPT entry, the kernel rereads the table, and the partition is bigger. If the power fails during the operation, the old size is still valid — you just didn't grow it yet.
+
+The e2fsck bug came back. Different script, same lesson. `set -euo pipefail` and `e2fsck` still don't agree on what exit code 1 means. But this time the agents caught something deeper: what if `e2fsck` finds *serious* corruption? Exit codes 0-3 are fixable. Exit code 4 means uncorrected errors — the kind of corruption where letting `e2fsck -y` auto-repair might make things worse, rewriting directory structures based on guesses about what the filesystem was supposed to look like. On a clean system, `-y` is fine. On a filesystem with deep structural damage, `-y` is a coin flip that might delete your files while "fixing" them.
+
+The fix was a two-pass approach: first `e2fsck -f -n` (read-only, don't touch anything), check the exit code. If it's 4 or higher, abort with a message that says "DO NOT auto-repair /home — run e2fsck manually." If it's 0-3, proceed with `e2fsck -f -y` for actual repair. The read-only pass costs thirty seconds and prevents the script from cheerfully destroying a corrupted filesystem on autopilot.
+
+Then round five found the thing that made me sit back in my chair.
+
+When nvme0n1p1 was mounted as `/home` in the original system, the filesystem root contained `cativo23/` directly — not `home/cativo23/`. That's how mount points work: you mount a partition at `/home`, and the top-level directories on that partition *become* what's under `/home`. The partition itself doesn't know it's called `/home`. It just has a directory called `cativo23/` at its root.
+
+After the migration, that partition *is* root. The filesystem root now contains `cativo23/` where it should contain `home/cativo23/`. Without relocation, the user's home directory would be at `/cativo23` instead of `/home/cativo23`. Every dotfile, every path in every config, every `$HOME` reference — wrong. The system would boot, but nothing would work the way it should.
+
+```bash
+if [ -d "$NEWROOT/cativo23" ] && [ ! -d "$NEWROOT/home/cativo23" ]; then
+    mkdir -p "$NEWROOT/home"
+    mv "$NEWROOT/cativo23" "$NEWROOT/home/cativo23"
+fi
+```
+
+Four lines. The `mv` is atomic on ext4 — it's a single directory rename within the same filesystem, so there's no partial state if the power fails mid-operation. The conditional makes it idempotent: if you run the script twice, the second run sees `/home/cativo23` already exists and skips the move. The kind of fix that's obvious *after* someone points it out, and invisible *before*.
+
+A dry-run simulator found it. An agent that was told "mentally execute every line with this exact filesystem layout" and traced what each directory check would see. It flagged the user relocation as CRITICAL because it simulated what `/mnt/newroot/cativo23` would look like after mounting a partition that had been /home. None of the other agents — the code reviewer, the chaos engineer, the boot specialist — noticed. They were looking at the code. The simulator was looking at the data.
+
+---
+
+## The Quiet Bugs
+
+Not every fix was dramatic. Some were the kind of thing you'd miss reading the script at midnight but would bite you at runtime.
+
+`grep -oP` — the Perl-compatible regex flag — doesn't exist on every system. Some minimal environments ship `grep` without PCRE support. On a live USB, you're running whatever the ISO packed. The script extracted UUIDs from GRUB config using `-oP` with `|| true` to suppress errors, which meant if PCRE wasn't supported, grep would fail silently, the UUID variable would be empty, and the mismatch check would pass because you can't mismatch against nothing. The fix was `grep -oE` (extended regex, always available) plus `sed` for the extraction.
+
+The backup script used `blockdev --getsize64` to check partition size before formatting. The command was wrapped in `|| true` on the assignment line — standard shell defensiveness. But `|| true` on an assignment means the assignment *always succeeds*: if `blockdev` fails, the variable is empty, and `|| true` prevents `set -e` from catching it. The subsequent arithmetic would either fail with "integer expression expected" (ugly) or silently compute with zero (dangerous). The fix was removing `|| true` from the assignment and adding an explicit check for empty or zero afterward.
+
+The GRUB UUID check deserves its own paragraph. The script checked `/etc/default/grub` for hardcoded `root=UUID=` entries that might not match the new root UUID. The first draft warned about the mismatch but didn't pause — it printed a warning, then ran `grub-mkconfig`, which dutifully generated a `grub.cfg` pointing at the wrong partition. The system would boot, GRUB would load, and the kernel would panic because root doesn't exist at that UUID. A NO-GO finding from round four: the warning must pause with `read -r` and let you fix the file *before* grub-mkconfig runs, not after.
+
+---
+
+## Running It
+
+I copied `automigrate.sh` to the same Kingston 58G USB that saved me last time. Booted the Arch live ISO. The familiar terminal. The familiar `lsblk` prayer:
+
+```
+nvme0n1     476.9G
+├─nvme0n1p1   432G ext4
+└─nvme0n1p2  44.9G ext4
+
+nvme1n1      27.3G
+├─nvme1n1p1     1G vfat
+└─nvme1n1p2  26.2G ext4
+```
+
+Same names this time. The PCIe bus was feeling cooperative. Or maybe the kernel was in a good mood. Either way, the device paths matched. The script's pre-flight checks passed: live USB confirmed, no stale mounts, backup verified with sentinel present, /home data confirmed (`cativo23/` found on nvme0n1p1).
+
+Press Enter to delete nvme0n1p2. One keypress. The partition that held my root for a month — the partition I'd spent the previous migration so carefully creating — gone in a fraction of a second. `sgdisk -d 2`. The GPT entry disappears. The blocks are still there, the data is still there, but the partition table no longer acknowledges it. Digital amnesia.
+
+`parted resizepart 1 100%`. The partition grows. `e2fsck` runs — clean, exit code 0, no drama. `resize2fs` expands the filesystem to fill the new space. The user relocation fires: `cativo23/` moves to `home/cativo23/`. `rsync` copies root files from the backup. fstab is written — one line for `/`, one for `/boot`, nothing for `/home` because `/home` is just a directory now. `arch-chroot` installs GRUB, generates the config, verifies UUIDs match, regenerates initramfs.
+
+Reboot. Pull the USB. Wait.
+
+```
+/dev/nvme1n1p1  469G  104G  342G  24% /
+```
+
+Wait. `nvme1n1`?
+
+The disks swapped names *again*. What was `nvme0n1` during the migration is now `nvme1n1` after reboot. The 477G NAND is now `nvme1n1`. The Optane is `nvme0n1`. The kernel, once again, enumerated them in a different order because PCIe bus topology is a suggestion, not a contract.
+
+But it didn't matter. The fstab uses UUIDs. GRUB uses UUIDs. The kernel command line uses UUIDs. Nothing in the boot chain references `/dev/nvme*` by name. The disk can call itself whatever it wants. The UUID doesn't change when the name does.
+
+```
+$ df -h /
+Filesystem      Size  Used Avail Use% Mounted on
+/dev/nvme1n1p1  469G  107G  339G  24% /
+
+$ ls /home/cativo23
+Desktop  Documents  Downloads  Music  Pictures  projects  Videos
+
+$ cat /etc/fstab
+UUID=259d7476-eecc-4fee-8a70-7bdeb2ee8592  /       ext4  rw,relatime  0 1
+UUID=2DC9-9D33 /boot   vfat  rw,relatime,...  0 2
+```
+
+One partition. 339 gigs free. No separate /home. No symlink hacks for Docker. No relocating Flatpak. No negotiating with `df -h` every time I install something. The number just goes up, slowly, from one pool, the way it should.
+
+---
+
+## What Changed
+
+The first migration was survival. Root was on a 27-gig Optane drive and it was full. I moved it to a 45-gig partition on the NAND because that was the space available — the rest was /home. It worked. It bought me a month.
+
+The second migration was admitting the first one was a patch, not a fix. Forty-four gigabytes is not enough for a modern Linux root that runs Docker and Flatpak and has opinions about package caching. The correct answer was always one partition, and I spent a month learning that the hard way — watching the usage bar climb, moving things to /home one by one, pretending the two-partition layout made sense for a laptop that belongs to one person.
+
+The technical difference between the two migrations: last time I shrank a partition and created a new one next to it. This time I deleted a partition and grew the surviving one. Last time the data I cared about was untouched. This time my /home was on the partition being resized. The stakes were higher, so the process was slower. Six review rounds instead of one. Two scripts instead of one. A sentinel file to prove the backup finished. A read-only `e2fsck` pass before the real one. A user-directory relocation step that wouldn't have existed if I'd thought harder about mount-point semantics before round five.
+
+The AI difference: last time, the reviews caught five bugs in one round. This time, twenty-four agents across six rounds caught ten bugs — including three that would have destroyed /home or left the system unbootable. The agents disagreed with each other. One thought the e2fsck handling was fine; another traced exit code 2 through the bash error propagation and found it wasn't. One said the rsync excludes were correct; the simulator said they were correct *but the directory layout wouldn't be what you expect*. Parallel review isn't just redundancy — it's adversarial. Different perspectives find different bugs.
+
+But the most important thing I learned is simpler than any of that.
+
+Two partitions on a single-user laptop are a mistake. Not because they fail — they work fine, technically. But they create a capacity-planning problem on a machine that doesn't need capacity planning. You're guessing how much space root needs, and you will guess wrong. You will always guess wrong, because the answer changes every time you install something, and you can't predict what you'll install in six months. One partition eliminates the question. The disk is full when it's full, and until then, everything has room.
+
+I should have done this from the beginning. But if I'd done it from the beginning, I wouldn't have two blog posts, three USB boots, twenty-four review agents, and the knowledge that NVMe device names will betray you every single time.
+
+The fan hums. The terminal glows. I type `df -h` one more time — not to check, just to look at it. 339 gigs free. The number is so large it feels fake, like finding money in a coat pocket. I close the terminal. I should go to bed.
+
+It's not 1am this time. It's only 11. Progress.

--- a/content/blog/three-boots-at-1am.md
+++ b/content/blog/three-boots-at-1am.md
@@ -1,0 +1,222 @@
+---
+title: "Three Boots at 1am: Migrating Root With Claude Code"
+created_at: 2026-03-12T01:00:00Z
+updated_at: 2026-03-12T01:00:00Z
+image: "/img/blog/alexander-grigoryev-YSEp8dLK8K8-unsplash.jpg"
+author: "Carlos Cativo"
+description: "How I moved my Arch Linux root from a 27G Intel Optane to a 476G NVMe at 1am, guided by an AI that caught its own bugs when I asked it to look."
+tags: ["arch-linux", "sysadmin", "claude-code", "nvme"]
+---
+
+The third time you boot from a USB stick at 1am, you stop reading the output. You just stare at it. The terminal glows in the dark and you type `lsblk` like a prayer, and the disks have switched names again. nvme0n1 is now what nvme1n1 was an hour ago. The script you trusted — the script you trusted more than you trust most people — just tried to repartition the wrong disk.
+
+You sit back. The fan hums. Somewhere deep in `drivers/nvme/host/core.c`, a function called `nvme_init_ctrl` decided to enumerate your drives in a different order, because the PCIe bus topology felt like it today. No promise was broken. None was ever made.
+
+This is the story of how that happened.
+
+---
+
+## The Problem
+
+My Dell laptop came with two NVMe drives: an Intel Optane H10 — 27 gigabytes of 3D XPoint doing its best impression of usefulness — and a regular NAND, 476 gigabytes of actual storage. When I installed Arch, the installer saw the Optane first, so root landed on it. /home went to the NAND. Fast disk for the system. Big disk for files. The kind of logic that sounds brilliant at midnight and stupid by morning.
+
+It stopped making sense around the time `df -h` started reading like a threat:
+
+```
+/dev/nvme0n1p2   26G   22G   3G   88% /
+/dev/nvme1n1p1  476G   22G  432G   5% /home
+```
+
+Root at 88%. Home at 5%. Every `pacman -S` was a diplomatic negotiation with three gigabytes of free space. `docker pull` was out of the question. Even `journalctl` was slowly eating me alive — systemd doesn't believe in moderation when it comes to logging. I was rationing installs on a machine with 450 gigs sitting empty, like owning a mansion and sleeping in the closet.
+
+The fix was obvious: move root to the big disk. Shrink the ext4 filesystem on the NAND, split the partition, `rsync` everything over, regenerate GRUB. The kind of thing that's three sentences to describe and three hours to survive.
+
+---
+
+## The Plan
+
+I'd spent the entire day installing Arch from scratch — wiped Windows, configured everything from the bootloader up, fought with drivers, got Hyprland running, set up my whole environment. By 1am I was done, running `df -h` out of habit, and that's when I saw root sitting at 88% on the Optane. The system I'd just spent twelve hours building was already out of space. I was not going to reinstall. Not tonight. Not after all that. I knew how to do the migration manually — I'd done partition work before — but at 1am, tired, on my only machine, with no backup? My hands would be the most dangerous thing in the room. So the logic was simple: let the AI write the script, review it carefully, and if it fails, I'm reinstalling anyway — same outcome as if I fat-fingered `parted` at 1am by myself, except this way I might actually sleep tonight.
+
+So I asked Claude Code to write a script that would repartition my only computer. No backup disk. No second machine. No Timeshift snapshot. But I didn't type "plz fix my disks" and wait for magic. That's not how any of this works. I gave it the full picture: the current partition layout, the target layout, the exact sizes in GiB, which disk was which, what filesystem each partition used, where the EFI partition lived, that this had to run from a live USB where nothing is mounted by default. I told it the script needed to be interactive — confirmations at every step — because I wasn't going to let 400 lines of bash run unattended on my only machine. I told it to use `set -euo pipefail` and to verify UUIDs at the end. The more specific you are with the prompt, the less the AI has to guess. And when you're repartitioning live, you want zero guessing.
+
+It produced 400 lines of bash with 9 interactive steps. Colored output — cyan for info, green for success, red for failure, yellow for warnings. Helper functions: `info()`, `ok()`, `warn()`, `fail()`. Yes/no confirmations at every step, because the script was polite enough to ask before destroying things. It felt safe, the way a seatbelt feels safe right before the crash.
+
+---
+
+## The Reviews That Saved Everything
+
+Here's the thing about AI-generated code: the first draft is never the one you run. Not on production. Not on your only machine at 1am.
+
+Before running anything, I told Claude to review its own script — not once, but using multiple subagents in parallel, each one focused on a different class of problem. One checked the resize arithmetic. Another looked at error handling with `set -e`. Another traced every device path to see if they were consistent. Another checked the GRUB and fstab logic. They came back with five bugs. Two of them would have destroyed my filesystem.
+
+I read every single finding. Not because I didn't trust the AI — I trusted it enough to write the script — but because trust without verification is just hope, and hope doesn't survive `mkfs.ext4` on the wrong partition.
+
+The worst one was arithmetic. `resize2fs` takes a filesystem size. `parted resizepart` takes a partition *end position* — an offset from byte zero of the disk. The script would resize the filesystem to exactly 432 GiB, then set the partition end at 432 GiB:
+
+```bash
+resize2fs /dev/nvme1n1p1 432G     # filesystem: exactly 432 GiB
+parted resizepart 1 432GiB        # partition END at 432 GiB from disk start
+# partition START at ~1MiB (GPT alignment)
+# actual partition SIZE ≈ 431.999 GiB
+# filesystem overflows partition by 1 MiB → silent corruption
+```
+
+The filesystem would have been bigger than its container by one megabyte. The superblock wouldn't know. `fsck` wouldn't catch it. Writes near the end of the filesystem would land in unallocated space past the partition boundary. Not an error. Not a warning. Just data going to a place that doesn't belong to anyone, waiting to be overwritten by the next `mkfs`.
+
+The fix was two gigabytes of headroom:
+
+```bash
+resize2fs /dev/nvme1n1p1 430G     # 2 GiB smaller than partition
+```
+
+Paranoid? Sure. But `resize2fs` sizes the filesystem content, and `parted` sets an end offset from byte zero of the disk — the partition start alignment eats a megabyte you forgot to subtract. Two gigs of wasted space buys you sleep.
+
+The second bug was ironic. `e2fsck` has its own exit code scheme: 0 means no errors found, 1 means errors were found *and corrected* — success, in `e2fsck`'s mind, but not in bash's. The script had `set -euo pipefail`. Exit code 1 plus `set -e` means bash kills the script for succeeding:
+
+```bash
+set -euo pipefail
+e2fsck -f /dev/nvme1n1p1  # returns 1 = "I fixed things"
+# bash interprets 1 as failure → script aborts at step 1
+# you are now staring at a half-checked filesystem
+```
+
+The fix was a wrapper that treats exit codes 0 and 1 as success, because `e2fsck` has its own ideas about what success means.
+
+There were three more: a bare `grep` that would trigger `set -e` and kill the script if GRUB used a different config format (grep returns 1 on no match — sensing a pattern?), `rsync` without `--numeric-ids` which would scramble UID/GID mappings when run from a live USB where `cativo23` doesn't exist, and a hardcoded `root=UUID=...` in `/etc/default/grub` that would survive `grub-mkconfig` and point the bootloader at a partition that's no longer root.
+
+The AI found bugs in its own code before I ran it. Five bugs, two of them catastrophic, discovered by parallel review agents arguing with each other about edge cases. But here's what matters: it found them because I *asked* it to look. The default output — the first draft — had all five bugs. If I'd run that first draft, I'd be reinstalling Arch right now instead of writing this.
+
+AI code generation is not magic. It's a first draft that's really fast and mostly right. The AI is the tool. You're still the engineer.
+
+---
+
+## First Attempt: The Disk Swap
+
+I booted the Arch USB, mounted /home, ran the script. It died immediately. Well — it didn't die. It tried to `resize2fs` the Optane, which would have been worse.
+
+The script had every device path hardcoded. `/dev/nvme0n1` was the Optane in my running system. But the kernel on the USB stick enumerated them in reverse. The Optane was now `nvme1n1`. The NAND was `nvme0n1`. The script was about to shrink a 27-gigabyte drive to 430 gigs.
+
+Linux does not guarantee NVMe enumeration order between boots. The kernel walks the PCIe topology, finds controllers, and assigns `/dev/nvme*` in whatever order the bus scan completes. Reboot with a USB plugged in and the timing changes. It's not a bug. It's not documented as a feature either. It's just how `nvme_init_ctrl` works, and it will humble you at 1am.
+
+I went back to Claude, explained what happened — "the disks swapped names on the live USB, look at this `lsblk` output" — and asked for a fix. This is the part people skip when they talk about AI tools: you have to *tell it what went wrong*. Give it the error output. Give it the actual state of the world. The AI can't see your screen. It doesn't know the disks swapped unless you say so. The quality of the fix is directly proportional to the quality of the bug report.
+
+The fix was to stop trusting names and start trusting sizes:
+
+```bash
+for dev in /dev/nvme0n1 /dev/nvme1n1; do
+    size_gb=$(lsblk -bno SIZE "$dev" | head -1)
+    size_gb=$((size_gb / 1073741824))
+    if [[ $size_gb -lt 50 ]]; then
+        OPTANE_DISK="$dev"
+    else
+        NAND_DISK="$dev"
+    fi
+done
+```
+
+Twenty-seven is always less than fifty. The Optane can't lie about being small.
+
+---
+
+## Second Attempt: The Chicken and the Egg
+
+The script lived on /home. /home lived on the NAND. The script needed to `umount` the NAND to run `resize2fs` on it — because you can't resize a mounted ext4 filesystem downward, only upward. But if /home is unmounted, bash can't read the script, because the script is on /home. Classic deadlock. The kind of thing that makes you question whether you thought about this at all.
+
+I tried `umount -l` (lazy unmount) first, because it sounded clever. It detaches the mountpoint from the VFS but keeps the underlying block device busy until all file descriptors close. Which means `resize2fs` would still refuse to touch it. Lazy unmount: the systemd of unmounting. Sounds helpful, does nothing useful.
+
+Then I found a Kingston 58G in a drawer, copied the script to it with `cp ~/migrate-root.sh /mnt/usb/`, and booted again.
+
+Sometimes the solution to a systems problem is a thing you forgot you owned.
+
+---
+
+## Third Attempt: It Works
+
+Nine confirmations. Each one a small prayer typed into a dark terminal.
+
+`e2fsck -f` passed clean — exit code 0 this time, no fixes needed. `resize2fs` shrank the filesystem from 476 GiB to 430 GiB in about forty seconds. The progress bar moved in chunks, relocating blocks from the tail end of the filesystem to free space closer to the front. ext4 is good at this. It keeps a block bitmap and just... rearranges things. Quietly.
+
+`parted resizepart 1 432GiB` carved the partition boundary. `mkpart primary ext4 432GiB 100%` claimed the remaining ~45 GiB. `mkfs.ext4` formatted it in two seconds — the superblock, the group descriptors, the inode table, the journal. A brand new filesystem with nothing in it, waiting.
+
+Then the `rsync`:
+
+```bash
+rsync -axHAXv --numeric-ids /mnt/oldroot/ /mnt/newroot/
+```
+
+The `-a` flag is archive mode — recursive, preserves symlinks, permissions, timestamps, group, owner, device files, specials. `-x` stays on one filesystem, so it won't follow mountpoints into /home, /boot, /proc, or /sys. `-H` preserves hard links. `-A` preserves ACLs. `-X` preserves extended attributes. `--numeric-ids` is the one that matters most here: on a live USB, the user `cativo23` doesn't exist in `/etc/passwd`, so rsync would try to map UIDs by name, fail, and default to root. Every file owned by uid 1000 would become owned by uid 0. You'd boot into a system where your user can't read its own config files. `--numeric-ids` says "don't think, just copy the numbers." 13 gigabytes. About four minutes.
+
+`genfstab -U /mnt/newroot` generated a fresh `/etc/fstab` with the new UUIDs — because every `mkfs.ext4` creates a new UUID, and the old fstab still pointed at the old partition. Then `arch-chroot /mnt/newroot` to regenerate `grub.cfg` with `grub-mkconfig -o /boot/grub/grub.cfg` and rebuild the initramfs with `mkinitcpio -P`. The chroot exits. The script prints every UUID it found — root, home, boot — next to what fstab and GRUB expect. They match.
+
+Reboot. Pull the USB. The GRUB menu appears. Login screen loads. I type `df -h` the way you check your pulse after a fall:
+
+```
+/dev/nvme0n1p2   44G   14G   29G  32% /
+/dev/nvme0n1p1  423G   22G  379G   6% /home
+```
+
+```
+nvme0n1     476.9G
+├─nvme0n1p1   432G ext4   /home
+└─nvme0n1p2  44.9G ext4   /
+nvme1n1      27.3G
+├─nvme1n1p1     1G vfat   /boot
+└─nvme1n1p2  26.2G ext4
+```
+
+Twenty-nine gigabytes free. `findmnt` confirmed root on `nvme0n1p2`. `cat /etc/fstab` showed all UUIDs matching. `efibootmgr -v` showed GRUB still loading from the Optane's EFI partition. Everything pointed where it should.
+
+The old root on the Optane still intact, untouched, a fallback I hope I never need. If the new root ever corrupts, I can boot the USB, mount `nvme1n1p2`, fix GRUB, and be back in business. It's 22 gigs of insurance. Cheap.
+
+---
+
+## The Morning After
+
+The migration was done. Root had 29 gigs free. I gave it six hours before something filled it up again.
+
+I had 44 gigs now, but I'd watched how fast 26 gigs filled up. What would fill this one? Docker was the obvious answer. All those images, containers, volumes, build cache — everything living in `/var/lib/docker`, which lives on root. One `docker pull postgres` and you've lost a gigabyte. Three `docker-compose up` cycles with different Node versions and you're negotiating with `docker system prune` like it owes you money.
+
+I stopped Docker, rsync'd everything to `/home/docker`, pointed `data-root` at the new location, and started it back:
+
+```bash
+systemctl stop docker docker.socket containerd
+rsync -aAXH /var/lib/docker/ /home/docker/
+echo '{"data-root":"/home/docker"}' > /etc/docker/daemon.json
+systemctl start docker
+```
+
+The rsync needs `-AXH` because Docker's overlay2 storage driver cares about xattrs more than it cares about your feelings. `docker info | grep "Docker Root Dir"` confirmed `/home/docker`. Then `rm -rf /var/lib/docker` — the only `rm -rf` I've ever typed with genuine satisfaction.
+
+I asked Claude what else could bloat root over time. Pacman cache and systemd journals — both bottomless by default. Arch never cleans `/var/cache/pacman/pkg/` — every package you download stays there, old versions piling up alongside new ones. It's not a cache, it's a hoarder's closet. I enabled `paccache.timer` to trim it weekly:
+
+```bash
+sudo systemctl enable --now paccache.timer
+```
+
+Keeps the last three versions, deletes the rest. The kind of cleanup you set once and forget exists until it saves you six months later.
+
+Then `journalctl`. Systemd's journal defaults to 10% of the filesystem, capped at 4 gigs — which sounds reasonable until you realize that on a 44-gig root, that's 4.4 gigabytes of logs competing with your actual system. I found 800 megabytes already and the system was two months old. I tightened it in `/etc/systemd/journald.conf`:
+
+```ini
+SystemMaxUse=200M
+```
+
+Two hundred megabytes of logs is more than enough to debug anything you'll actually debug. The rest is just systemd narrating your life to `/var/log/journal/` like an unsolicited biographer.
+
+The Optane sits empty now. Twenty-seven gigabytes of 3D XPoint doing nothing. Intel designed that chip for caching — it was supposed to sit between the CPU and the NAND, accelerating reads with its absurdly low latency. That low latency — roughly 10 microseconds for Optane versus 20-100 for NAND flash — makes it a decent swap device, since swap is all about random small reads under memory pressure. `mkswap /dev/nvme1n1p2` and a line in fstab. Someday. For now it just holds the old root, untouched, a snapshot of the system from before I rearranged its organs at 1am because `df -h` hurt my feelings.
+
+I spent more time protecting 44 gigabytes than most people spend on backups.
+
+---
+
+## What I Know Now
+
+NVMe device names are suggestions, not promises — use `lsblk` sizes or `/dev/disk/by-uuid/` like a civilized person. `set -e` will kill your script for doing its job, and `e2fsck` will return 1 to thank you for asking. A filesystem must always be smaller than its partition, because `resize2fs` and `parted` don't agree on what a gigabyte is, and neither of them will warn you. Never delete the old root — it's the only thing between you and a four-hour reinstall at 3am. Docker doesn't belong on root, pacman doesn't clean up after itself, and systemd will happily dedicate 10% of your root to logs about how everything is fine.
+
+And about the AI thing: Claude Code wrote the script that migrated my root partition, found the bugs in its own script, fixed the disk enumeration issue when I reported it, and helped me harden the system afterward. It did all of that. But it did none of it unprompted. I described the problem in detail. I asked for specific reviews. I read every line of output. I told it when things broke and *how* they broke. Before the final run, I told Claude to double-check everything — run `shellcheck`, make sure nothing was off. It passed clean. The AI was the most competent pair programmer I've ever had — but it still needed a human at the keyboard who knew what questions to ask and when to say "wait, that doesn't look right."
+
+The people who say "AI will replace engineers" and the people who say "AI is useless" are both wrong in the same way. They both think it's supposed to work alone.
+
+The [full script is here](GIST_URL), if you're the kind of person who reads other people's bash scripts at 2am.
+
+Three boots, two catastrophic bugs caught before they fired, one partition table that finally makes sense, and a mass of 3D XPoint sitting idle because I haven't gotten around to `mkswap`. It's 2am. The fan hums. The terminal is still open. I should go to bed, but `df -h` looks so good now I keep running it.

--- a/content/blog/why-i-archived-qwen-claude-setup-and-switched-to-cliproxyapi.md
+++ b/content/blog/why-i-archived-qwen-claude-setup-and-switched-to-cliproxyapi.md
@@ -1,0 +1,68 @@
+---
+title: "Why I Archived qwen-claude-setup and Switched to CLIProxyAPI Dashboard"
+created_at: 2026-03-05T00:30:00Z
+updated_at: 2026-03-05T00:30:00Z
+image: "/img/blog/alexander-grigoryev-YSEp8dLK8K8-unsplash.jpg"
+author: "Carlos Cativo"
+description: "Why I moved from custom shell scripts to a Docker-based multi-provider AI proxy dashboard with real-time quota tracking."
+tags: ["ai", "docker", "infrastructure", "tooling", "open-source"]
+---
+
+If you've been following this blog, you know the journey. I built [qwen-claude-setup](https://github.com/cativo23/qwen-claude-setup) — a collection of shell scripts to route Claude Code through Qwen's free API using `claude-code-router`. It worked. It solved a real problem. But it had limitations:
+
+- **Single provider**: It only supported Qwen. If Qwen's free tier hit its daily cap, you were done for the day.
+- **Manual everything**: Refreshing tokens, restarting the router, editing config files by hand.
+- **Fragile glue**: Shell scripts wrapping npm packages wrapping a JavaScript transformer — a lot of moving parts for what's essentially "proxy AI requests."
+
+I kept thinking: *what if I could just switch between models on the fly?*
+
+## The Discovery: CLIProxyAPI + Dashboard
+
+Enter [CLIProxyAPI Dashboard](https://github.com/itsmylife44/cliproxyapi-dashboard).
+
+The concept is similar in spirit — wrap CLI-based AI tools into OpenAI-compatible APIs — but the execution is on another level. CLIProxyAPIPlus is the core proxy that handles OAuth for multiple providers, and the Dashboard gives you a full web UI to manage everything.
+
+**The key difference?** It's not just Qwen. It supports **Claude, Gemini, Codex, GitHub Copilot, Antigravity, Kimi, Qwen, and more** — all from a single interface.
+
+## My Setup
+
+I'm running it locally with Docker. The setup was absurdly simple:
+
+```bash
+git clone https://github.com/itsmylife44/cliproxyapi-dashboard.git
+cd cliproxyapi-dashboard
+./setup-local.sh
+```
+
+Open `http://localhost:3000`, create an admin account, and you're in the dashboard.
+
+### How I Use It
+
+The beauty is **model switching based on need**:
+
+- **Daily coding tasks** → Qwen (free tier, 1,000 req/day)
+- **Qwen quota exhausted** → Switch to Antigravity or Copilot
+- **Complex architecture work** → Pick whichever model handles it best
+- **Quick completions** → Copilot, since it's already paid for
+
+No restarting services. No editing config files. Just pick the model from the dashboard or hit a different endpoint.
+
+## What Makes It Better
+
+| | qwen-claude-setup | CLIProxyAPI Dashboard |
+|---|---|---|
+| **Providers** | Qwen only | Qwen, Copilot, Antigravity, Claude, Gemini, and more |
+| **Config** | JSON files + shell scripts | Web UI |
+| **Token refresh** | CLI commands | One click in browser |
+| **Quota visibility** | Manual script | Real-time dashboard |
+| **Installation** | Distribution-specific scripts | `docker compose up` |
+| **Model switching** | Edit config, restart router | Switch from the dashboard |
+
+## Lessons Learned
+
+1. **Don't reinvent the wheel** — I spent weeks building shell scripts, transformer plugins, and distro-specific installers. A Docker-based solution with a web UI would have been the right answer from day one.
+2. **Multi-provider matters** — Betting on a single free tier is fragile. Having fallbacks means I never hit a wall mid-session.
+3. **UIs beat config files** — I'm a terminal person. I *like* config files. But managing OAuth tokens across multiple providers through a dashboard is just objectively better.
+4. **Know when to archive** — It's tempting to keep maintaining your own thing. But if someone else built a better solution, use it and move on. That's what open source is for.
+
+There's no reason to maintain custom shell scripts when a well-built tool already exists. The old repo is archived — the code stays up for reference and anyone curious about the journey.


### PR DESCRIPTION
## Summary
- Adds 14 new blog posts covering the AI journey (Qwen/Claude integration), Nova ID Zero Trust dev diary, and space server infrastructure hardening
- All posts preserve their original creation dates in frontmatter
- Uses existing blog image for all posts

## Posts Added

### Qwen AI Integration (4 posts)
- How I Created a Free Claude Code Setup Using Qwen AI (2026-02-02)
- Fixing Web Search: Bridging Claude CLI and Qwen Models (2026-02-02)
- Migrating to qwen-claude CLI & Navigating Qwen Quota Changes (2026-02-08)
- Why I Archived qwen-claude-setup and Switched to CLIProxyAPI (2026-03-05)

### Nova ID Dev Diary (8 posts)
- Day 1: Starting the Zero Trust Journey (2026-01-15)
- Day 2-3: Setting Up the Infrastructure (2026-01-16)
- Day 4-5: Building the Authorization System (2026-01-18)
- Day 6-8: Frontend Development (2026-01-20)
- Day 9-15: The Problem-Solving Marathon (2026-01-23)
- Day 16: Looking Forward (2026-01-30)
- Day 17: Architecture Refactor (2026-01-31)
- Day 18: Full Ory Stack Integration (2026-02-01)

### Space Server (2 posts)
- Migrating and Securing My Space Server Infrastructure (2026-03-21)
- Configurando un Servidor de Correo Self-Hosted con Docker (2026-03-26)