### PR TITLE
🐛 hotfix: remove better-sqlite3 from prod Dockerfile after blog removal

### DIFF
--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -2,52 +2,43 @@
   FROM node:22-alpine AS build
 
   WORKDIR /app
-  
-  RUN apk add --no-cache --virtual .build-deps \
-      python3 \
-      make \
-      g++ \
-      sqlite-dev
-  
+
   COPY package.json yarn.lock ./
   RUN yarn install
-  
+
   COPY . .
-  
+
   ENV NITRO_PRESET=node-server
-  
+
   ARG NUXT_API_BASE_URL
   ARG NUXT_API_BASE_PATH
   ARG NUXT_API_TOKEN
   ENV NUXT_API_BASE_URL=${NUXT_API_BASE_URL}
   ENV NUXT_API_BASE_PATH=${NUXT_API_BASE_PATH}
   ENV NUXT_API_TOKEN=${NUXT_API_TOKEN}
-  
+
   RUN yarn nuxt prepare
   RUN yarn build
-  
+
   # ---- Stage 2: Production runtime ----
   FROM node:22-alpine AS runtime
-  
+
   LABEL org.opencontainers.image.authors="cativo23.kt@gmail.com"
-  
+
   ENV NODE_ENV=production
-  
+
   WORKDIR /app
-  
-  RUN apk add --no-cache sqlite-libs
-  
+
   RUN addgroup --system --gid 1001 nuxt && \
       adduser --system --uid 1001 --ingroup nuxt nuxt
-  
+
   COPY --from=build --chown=nuxt:nuxt /app/.output ./.output
-  COPY --from=build --chown=nuxt:nuxt /app/node_modules/better-sqlite3 ./node_modules/better-sqlite3
-  
+
   USER nuxt
-  
+
   EXPOSE 3000
-  
+
   HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \
     CMD node -e "fetch('http://localhost:3000').then(r => { if (!r.ok) process.exit(1) }).catch(() => process.exit(1))"
-  
+
   CMD ["node", ".output/server/index.mjs"]


### PR DESCRIPTION
## Summary

- Removes `better-sqlite3` COPY step from prod Dockerfile — package was removed with the blog in v1.8.0 but the Dockerfile was not updated, causing the Docker build to fail on deploy.
- Removes `sqlite-dev` build deps and `sqlite-libs` runtime package (no longer needed).

## Root cause

Blog removal in v1.8.0 uninstalled `better-sqlite3` from `package.json` but the prod Dockerfile still tried to copy it from the build stage, causing a checksum error.