### PR TITLE
⚙️ chore(ci): bump actions/checkout to v5

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Extract and validate version
         id: version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Use Node.js 22.x
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     environment: prod
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name }}
 
@@ -58,7 +58,7 @@ jobs:
     environment: prod
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name }}
       - name: Copy compose file to server


### PR DESCRIPTION
## Summary
- Bump `actions/checkout@v4` → `@v5` across `auto-release.yml`, `ci.yml`, and `deploy.yml`.

## Why
GitHub Actions deprecation notice: Node.js 20 will be forced to Node.js 24 by default starting June 2nd, 2026, and removed entirely September 16th, 2026. `actions/checkout@v5` ships on Node.js 24.

## Test plan
- [ ] CI workflow runs green on this PR
- [ ] No deprecation warning in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)