### PR TITLE
🚀 Release 1.8.2

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Extract and validate version
         id: version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Use Node.js 22.x
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     environment: prod
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name }}
 
@@ -58,7 +58,7 @@ jobs:
     environment: prod
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name }}
       - name: Copy compose file to server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.8.2] - 2026-05-01
+
+### Changed
+- **CI** — Bumped `actions/checkout` from v4 to v5 across all workflows to stay ahead of the Node.js 20 → 24 deprecation on GitHub Actions runners.
+
+### Fixed
+- **Deploy** — Restored automatic production deploys after migrating the server from homelab to Hetzner. Updated `SSH_HOST`, `SSH_PORT`, and `SSH_PRIVATE_KEY` secrets in the `prod` environment.
+
+---
+
 ## [1.8.1] - 2026-05-01
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-app",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- ⚙️ Bump `actions/checkout` v4 → v5 across all workflows (Node.js 24 ready)
- 🐛 Restore production auto-deploy after Hetzner migration (updated SSH secrets in `prod` environment)

## Test plan
- [x] Manual deploy verified — `portfolio-prod-app-1` healthy on Hetzner
- [x] CI build green on develop after merge of #82
- [ ] Auto-release workflow creates `v1.8.2` tag on merge
- [ ] Deploy workflow ships `v1.8.2` to production

🤖 Generated with [Claude Code](https://claude.com/claude-code)