### PR TITLE
✨ feat: UI polish — proof-of-work panel, scroll reveals, design system fixes

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -9,12 +9,13 @@ services:
       - .:/home/node/app
       - /home/node/app/node_modules  # Preserve container's node_modules
     ports:
-      - '3001:3000'
+      - '3002:3000'
     environment:
       NODE_ENV: development
       NUXT_API_BASE_URL: http://host.docker.internal:3003
       NUXT_API_BASE_PATH: /api/v1
       NUXT_API_TOKEN: ${NUXT_API_TOKEN:-}
+      GITHUB_TOKEN: ${GITHUB_TOKEN:-}
     user: 'node'
     extra_hosts:
       - 'host.docker.internal:host-gateway'

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -29,6 +29,7 @@ export default defineNuxtConfig({
     apiBaseUrl: process.env.NUXT_API_BASE_URL || 'http://api:3000',
     apiBasePath: process.env.NUXT_API_BASE_PATH || '/api/v1',
     apiToken: process.env.NUXT_API_TOKEN || '',
+    githubToken: process.env.GITHUB_TOKEN || '',
     public: {
       baseTitle: 'Carlos Cativo',
       defaultOgImage: '/img/akira.jpeg',

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -6,8 +6,6 @@
    tokens still rule panels (metric-cell, kv-row, panel-header).
    ============================================================ */
 :root {
-  /* Body prose: fluid 19→20px. Slightly bigger than the readability
-     target — user preference for a more comfortable read. */
   --text-body:       clamp(19px, 1.05rem + 0.25vw, 20px);
   --text-lede:       clamp(17px, 0.95rem + 0.3vw, 19px);
   --leading-body:    1.65;
@@ -23,7 +21,14 @@
   --tracking-body:   -0.005em;
 }
 
-/* Pure Nightwire, mono everywhere, OLED-friendly via dim body */
+/* GPU-accelerate compressed titles to prevent clipping artefacts
+   from the scaleX(0.82) transform on low-DPI displays. */
+.compressed-title {
+  will-change: transform;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+}
+
 html,
 body {
   background: var(--void);
@@ -79,6 +84,11 @@ body {
   line-height: 1.2;
 }
 
+.title-card-lg {
+  font-size: 1.75rem;
+  line-height: 1.15;
+}
+
 /* Mobile: clamp already lands at 17px, but we open up line-height
    slightly because reading-on-thumb tolerates more air. */
 @media (max-width: 480px) {
@@ -108,6 +118,19 @@ body {
 
 @keyframes nw-caret-blink {
   50% { opacity: 0; }
+}
+
+/* Scroll-triggered reveal — elements start invisible, fade+slide in
+   when IntersectionObserver adds .is-visible. Stagger via --delay. */
+.reveal {
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 0.5s ease-out, transform 0.5s ease-out;
+  transition-delay: var(--delay, 0s);
+}
+.reveal.is-visible {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 /* Page transition — clean fade */

--- a/src/components/about/Timeline.vue
+++ b/src/components/about/Timeline.vue
@@ -28,10 +28,10 @@
             <div class="flex-1">
               <p class="text-nw-primary text-xs uppercase tracking-wider mb-3 font-stamp">{{ item.company }}</p>
 
-              <p class="text-nw-text-dim mb-4 leading-relaxed">{{ item.description }}</p>
+              <p class="text-meta mb-4 leading-relaxed">{{ item.description }}</p>
 
               <ul v-if="item.highlights && item.highlights.length > 0" class="space-y-2 mb-4">
-                <li v-for="(highlight, i) in item.highlights" :key="i" class="text-nw-text-dim flex gap-2">
+                <li v-for="(highlight, i) in item.highlights" :key="i" class="text-meta flex gap-2">
                   <span class="text-nw-primary shrink-0 mt-0.5">→</span>
                   <span>{{ highlight }}</span>
                 </li>

--- a/src/components/home/Contact.vue
+++ b/src/components/home/Contact.vue
@@ -1,8 +1,13 @@
 <template>
-  <section class="mb-16" id="contact">
-    <BaseSectionHeading title="Contact me :)" animated :level="3" />
-    <div>
-      <form @submit.prevent="submitForm" class="bg-void-warm p-6 rounded-lg shadow-lg w-full flex flex-col gap-4">
+  <div class="panel" id="contact">
+    <div class="panel-header">
+      <span>OPEN CHANNEL · DIRECT LINE</span>
+    </div>
+    <div class="panel-body p-6 lg:p-8">
+      <p class="text-nw-text-dim leading-relaxed mb-6">
+        No intake forms. No synergy decks. Just a conversation about what you're building.
+      </p>
+      <form @submit.prevent="submitForm" class="max-w-xl flex flex-col gap-4">
         <BaseInput
           v-model="form.name"
           label="Name"
@@ -29,12 +34,12 @@
         />
         <div v-if="error" class="text-nw-red font-sys">{{ error }}</div>
 
-        <BaseButton type="submit" :loading="loading" :disabled="loading">
+        <BaseButton type="submit" :loading="loading" :disabled="loading" variant="primary">
           Send message
         </BaseButton>
       </form>
     </div>
-  </section>
+  </div>
 </template>
 
 <script lang="ts" setup>
@@ -42,5 +47,3 @@ import { useContactForm } from '~/composables/useContactForm';
 
 const { form, loading, error, submitForm } = useContactForm();
 </script>
-
-<style></style>

--- a/src/components/home/Hero.vue
+++ b/src/components/home/Hero.vue
@@ -1,7 +1,6 @@
 <template>
-  <section class="py-8 lg:py-12">
-    <!-- PERSONNEL DOSSIER -->
-    <div class="panel">
+  <!-- PERSONNEL DOSSIER -->
+  <div class="panel">
       <div class="panel-header">
         <span>PERSONNEL DOSSIER · ID-SV-001</span>
         <span class="tag">人事ファイル</span>
@@ -89,7 +88,6 @@
         </aside>
       </div>
     </div>
-  </section>
 </template>
 
 <script lang="ts" setup>

--- a/src/components/home/ProofOfWork.vue
+++ b/src/components/home/ProofOfWork.vue
@@ -185,7 +185,7 @@ const monthLabels = computed(() => {
     const approxDate = new Date(now.getTime() - (weeks.length - 1 - wi) * 7 * 24 * 60 * 60 * 1000)
     const month = approxDate.getMonth()
     if (month !== lastMonth) {
-      labels.push({ name: MONTH_NAMES[month], index: wi })
+      labels.push({ name: MONTH_NAMES[month] ?? '', index: wi })
       lastMonth = month
     }
   })

--- a/src/components/home/ProofOfWork.vue
+++ b/src/components/home/ProofOfWork.vue
@@ -149,10 +149,8 @@ interface SignalData {
   api: { version: string; status: string }
 }
 
-const signalVersion = 3
 const { data: raw } = useFetch<{ status: string; data: SignalData }>('/api/signal', {
   server: false,
-  query: { v: signalVersion },
 })
 
 const signal = computed(() => raw.value?.data)

--- a/src/components/home/ProofOfWork.vue
+++ b/src/components/home/ProofOfWork.vue
@@ -5,28 +5,99 @@
       <span class="text-nw-green font-stamp uppercase tracking-wider text-[10px]">LIVE</span>
     </div>
 
-    <!-- GitHub Heatmap -->
-    <div class="px-5 py-4 flex items-center gap-6 border-b border-nw-text-faint">
-      <div v-if="signal?.github.weeks.length" class="heatmap-grid shrink-0">
-        <div v-for="(week, wi) in signal.github.weeks" :key="wi" class="heatmap-col">
-          <div
-            v-for="(level, di) in week"
-            :key="di"
-            class="heatmap-cell"
-            :style="{ background: heatColors[level] || heatColors[0] }"
-          />
+    <!-- Row 1: Heatmap with month axis + Stats Grid 2x3 -->
+    <div class="flex items-stretch border-b border-nw-text-faint">
+      <!-- Heatmap zone (flex-grow, responsive cells) -->
+      <div class="flex-grow px-5 py-4 flex flex-col justify-center gap-1 overflow-hidden">
+        <div v-if="signal?.github.weeks.length" class="heatmap-grid w-full">
+          <div v-for="(week, wi) in signal.github.weeks" :key="wi" class="heatmap-col">
+            <div
+              v-for="(level, di) in week"
+              :key="di"
+              class="heatmap-cell"
+              :style="{ background: heatColors[level] || heatColors[0] }"
+            />
+          </div>
         </div>
+        <!-- Month axis -->
+        <div v-if="signal?.github.weeks.length" class="heatmap-axis w-full">
+          <span
+            v-for="label in monthLabels"
+            :key="label.index"
+            class="font-stamp text-nw-text-dim"
+            :style="{ position: 'absolute', left: `${(label.index / (signal.github.weeks.length - 1)) * 100}%` }"
+            style="font-size: 8px; letter-spacing: 0.08em; text-transform: uppercase;"
+          >{{ label.name }}</span>
+        </div>
+        <div v-else class="w-[200px] h-[84px] bg-void-panel" />
       </div>
-      <div v-else class="w-[200px] h-[84px] bg-void-panel" />
-      <div class="font-stamp uppercase tracking-wider text-[9px] text-nw-text-dim leading-loose whitespace-nowrap">
-        <span class="text-nw-green font-bold text-xs">{{ signal?.github.contributions ?? '...' }}</span> contributions<br>
-        <span class="text-nw-cyan font-bold text-xs">{{ signal?.github.publicRepos ?? '...' }}</span> public repos<br>
-        <span class="text-nw-purple font-bold text-xs">3</span> npm packages
+
+      <!-- Stats grid 2x3 -->
+      <div class="grid grid-cols-2 gap-px bg-nw-text-faint shrink-0 w-[340px]">
+        <div class="metric-cell">
+          <div class="m-value" style="color: var(--nw-green); text-shadow: 0 0 6px rgba(122,237,122,0.3);">
+            {{ signal?.github.contributions ?? '...' }}
+          </div>
+          <div class="m-label">Contributions</div>
+        </div>
+        <div class="metric-cell">
+          <div class="m-value" style="color: var(--nw-cyan); text-shadow: 0 0 6px rgba(102,221,255,0.3);">
+            {{ signal?.github.publicRepos ?? '...' }}
+          </div>
+          <div class="m-label">Public Repos</div>
+        </div>
+        <div class="metric-cell">
+          <div class="m-value" style="color: var(--nw-purple); text-shadow: 0 0 6px rgba(178,102,224,0.3);">
+            {{ formatNumber(signal?.npm.total) }}
+          </div>
+          <div class="m-label">NPM DL / mo</div>
+        </div>
+        <div class="metric-cell">
+          <div class="m-value" style="color: var(--nw-primary); text-shadow: 0 0 6px rgba(102,153,255,0.3);">
+            3
+          </div>
+          <div class="m-label">NPM Packages</div>
+        </div>
+        <div class="metric-cell">
+          <div class="m-value" style="font-size: 16px;">
+            {{ signal ? `v${signal.api.version}` : '...' }}
+          </div>
+          <div class="m-label">API</div>
+        </div>
+        <div class="metric-cell">
+          <div class="m-value" style="font-size: 14px;">
+            <span class="led blink" :class="signal?.api.status === 'operational' ? 'green' : 'red'" style="display: inline-block;" />
+          </div>
+          <div class="m-label">Status</div>
+          <div class="m-sub">api.cativo.dev</div>
+        </div>
       </div>
     </div>
 
-    <!-- Metrics strip -->
-    <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-px bg-nw-text-faint">
+    <!-- Row 2: NPM Sparkline Strip -->
+    <div v-if="npmPackages.length" class="flex items-center px-5 py-2.5 gap-8 border-b border-nw-text-faint">
+      <span class="font-stamp uppercase tracking-wider text-[8px] text-nw-text-dim shrink-0">NPM Downloads</span>
+      <div class="flex items-center gap-8 flex-grow justify-around">
+        <div v-for="pkg in npmPackages" :key="pkg.name" class="flex items-center gap-3">
+          <span class="font-stamp uppercase tracking-wider text-[9px] text-nw-text-dim">{{ pkg.name }}</span>
+          <div class="sparkline">
+            <div
+              v-for="(val, i) in pkg.weekly"
+              :key="i"
+              class="spark-bar"
+              :style="{
+                height: sparkBarHeight(val, pkg.weekly) + 'px',
+                background: val === sparkMax(pkg.weekly) ? 'var(--nw-primary)' : 'var(--nw-primary-dim)',
+              }"
+            />
+          </div>
+          <span class="text-nw-cyan font-bold text-[11px]">{{ formatNumber(pkg.monthly) }}</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Metrics strip (4 cells — API/Status moved to stats grid) -->
+    <div class="grid grid-cols-2 sm:grid-cols-4 gap-px bg-nw-text-faint">
       <div class="metric-cell">
         <div class="m-label">YEARS</div>
         <div class="m-value">9</div>
@@ -46,32 +117,6 @@
         <div class="m-label">CONTAINERS</div>
         <div class="m-value">16</div>
         <div class="m-sub">self-hosted · 6 stacks</div>
-      </div>
-      <div class="metric-cell">
-        <div class="m-label">NPM DL / MO</div>
-        <div class="m-value" style="color: var(--nw-purple); text-shadow: 0 0 6px rgba(178,102,224,0.3);">
-          {{ formatNumber(signal?.npm.total) }}
-        </div>
-      </div>
-      <div class="metric-cell">
-        <div class="m-label">LUMIRA</div>
-        <div class="m-value" style="color: var(--nw-cyan); text-shadow: 0 0 6px rgba(102,221,255,0.3);">
-          {{ formatNumber(signal?.npm.lumira) }}
-        </div>
-        <div class="m-sub">downloads / mo</div>
-      </div>
-      <div class="metric-cell">
-        <div class="m-label">API</div>
-        <div class="m-value" style="font-size: 16px;">
-          {{ signal ? `v${signal.api.version}` : '...' }}
-        </div>
-      </div>
-      <div class="metric-cell">
-        <div class="m-label">STATUS</div>
-        <div class="m-value" style="font-size: 14px;">
-          <span class="led blink" :class="signal?.api.status === 'operational' ? 'green' : 'red'" style="display: inline-block;" />
-        </div>
-        <div class="m-sub">api.cativo.dev</div>
       </div>
     </div>
 
@@ -93,19 +138,77 @@
 </template>
 
 <script setup lang="ts">
+interface NpmPackageData {
+  monthly: number
+  weekly: number[]
+}
+
 interface SignalData {
   github: { contributions: number; weeks: number[][]; publicRepos: number }
-  npm: { lumira: number; claudeSetup: number; nightwire: number; total: number }
+  npm: { lumira: NpmPackageData | number; claudeSetup: NpmPackageData | number; nightwire: NpmPackageData | number; total: number }
   api: { version: string; status: string }
 }
 
+const signalVersion = 3
 const { data: raw } = useFetch<{ status: string; data: SignalData }>('/api/signal', {
   server: false,
+  query: { v: signalVersion },
 })
 
 const signal = computed(() => raw.value?.data)
 
-const heatColors = ['var(--void-panel)', 'var(--nw-primary-fill)', 'rgba(68,119,204,0.45)', 'var(--nw-primary-dim)', 'var(--nw-primary)']
+function getNpmPkg(val: NpmPackageData | number | undefined): { monthly: number; weekly: number[] } {
+  if (val == null) return { monthly: 0, weekly: [] }
+  if (typeof val === 'number') return { monthly: val, weekly: [] }
+  return { monthly: val.monthly ?? 0, weekly: val.weekly ?? [] }
+}
+
+const npmPackages = computed(() => {
+  if (!signal.value) return []
+  const lumira = getNpmPkg(signal.value.npm.lumira)
+  const nightwire = getNpmPkg(signal.value.npm.nightwire)
+  const claudeSetup = getNpmPkg(signal.value.npm.claudeSetup)
+  return [
+    { name: 'Lumira', ...lumira },
+    { name: 'Nightwire', ...nightwire },
+    { name: 'Claude-Setup', ...claudeSetup },
+  ].filter(p => p.monthly > 0 || p.weekly.length > 0)
+})
+
+const MONTH_NAMES = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC']
+
+const monthLabels = computed(() => {
+  if (!signal.value?.github.weeks.length) return []
+  const weeks = signal.value.github.weeks
+  const labels: { name: string; index: number }[] = []
+  let lastMonth = -1
+  const now = new Date()
+  weeks.forEach((_, wi) => {
+    const approxDate = new Date(now.getTime() - (weeks.length - 1 - wi) * 7 * 24 * 60 * 60 * 1000)
+    const month = approxDate.getMonth()
+    if (month !== lastMonth) {
+      labels.push({ name: MONTH_NAMES[month], index: wi })
+      lastMonth = month
+    }
+  })
+  return labels
+})
+
+const heatColors = [
+  'var(--void-panel)',
+  'rgba(102,153,255,0.18)',
+  'rgba(80,130,220,0.45)',
+  'rgba(90,145,240,0.72)',
+  '#6699ff',
+]
+
+function sparkMax(weekly: number[]): number {
+  return Math.max(...weekly, 1)
+}
+
+function sparkBarHeight(val: number, weekly: number[]): number {
+  return Math.max(3, (val / sparkMax(weekly)) * 24)
+}
 
 function formatNumber(n: number | undefined): string {
   if (n == null) return '...'
@@ -115,19 +218,41 @@ function formatNumber(n: number | undefined): string {
 </script>
 
 <style scoped>
+/* Heatmap — responsive cells fill available width */
 .heatmap-grid {
   display: flex;
-  gap: 2px;
-  overflow: hidden;
+  justify-content: space-between;
 }
 .heatmap-col {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: clamp(1px, 0.3vw, 3px);
+  flex: 1;
+  max-width: 20px;
 }
 .heatmap-cell {
-  width: 10px;
-  height: 10px;
+  aspect-ratio: 1;
+  width: 100%;
   border-radius: 2px;
+  border: 1px solid rgba(102, 153, 255, 0.08);
+}
+
+/* Month axis */
+.heatmap-axis {
+  position: relative;
+  height: 12px;
+}
+
+/* Sparklines */
+.sparkline {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 24px;
+}
+.spark-bar {
+  width: 6px;
+  border-radius: 1px;
+  min-height: 3px;
 }
 </style>

--- a/src/components/home/ProofOfWork.vue
+++ b/src/components/home/ProofOfWork.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="panel reveal">
+  <div class="panel">
     <div class="panel-header">
       <span>SIGNAL · PROOF OF WORK</span>
       <span class="text-nw-green font-stamp uppercase tracking-wider text-[10px]">LIVE</span>
@@ -26,35 +26,52 @@
     </div>
 
     <!-- Metrics strip -->
-    <div class="metrics-grid grid grid-cols-2 md:grid-cols-5">
+    <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-px bg-nw-text-faint">
+      <div class="metric-cell">
+        <div class="m-label">YEARS</div>
+        <div class="m-value">9</div>
+        <div class="m-sub">backend since 2016</div>
+      </div>
+      <div class="metric-cell">
+        <div class="m-label">CURRENT ROLE</div>
+        <div class="m-value" style="font-size: 16px;">TECH LEAD</div>
+        <div class="m-sub">Blue Medical Guatemala</div>
+      </div>
+      <div class="metric-cell highlight">
+        <div class="m-label">SPECIALTY</div>
+        <div class="m-value" style="font-size: 12px;">PAYMENTS · FEL</div>
+        <div class="m-sub">ISO 8583 · multi-gateway</div>
+      </div>
       <div class="metric-cell">
         <div class="m-label">CONTAINERS</div>
         <div class="m-value">16</div>
+        <div class="m-sub">self-hosted · 6 stacks</div>
       </div>
       <div class="metric-cell">
         <div class="m-label">NPM DL / MO</div>
-        <div class="m-value" style="color: var(--nw-purple); text-shadow: 0 0 6px rgba(187,154,247,0.3);">
+        <div class="m-value" style="color: var(--nw-purple); text-shadow: 0 0 6px rgba(178,102,224,0.3);">
           {{ formatNumber(signal?.npm.total) }}
         </div>
       </div>
       <div class="metric-cell">
         <div class="m-label">LUMIRA</div>
-        <div class="m-value" style="color: var(--nw-cyan); text-shadow: 0 0 6px rgba(125,207,255,0.3);">
+        <div class="m-value" style="color: var(--nw-cyan); text-shadow: 0 0 6px rgba(102,221,255,0.3);">
           {{ formatNumber(signal?.npm.lumira) }}
         </div>
         <div class="m-sub">downloads / mo</div>
       </div>
       <div class="metric-cell">
-        <div class="m-label">API VERSION</div>
+        <div class="m-label">API</div>
         <div class="m-value" style="font-size: 16px;">
           {{ signal ? `v${signal.api.version}` : '...' }}
         </div>
       </div>
       <div class="metric-cell">
-        <div class="m-label">API STATUS</div>
+        <div class="m-label">STATUS</div>
         <div class="m-value" style="font-size: 14px;">
           <span class="led blink" :class="signal?.api.status === 'operational' ? 'green' : 'red'" style="display: inline-block;" />
         </div>
+        <div class="m-sub">api.cativo.dev</div>
       </div>
     </div>
 

--- a/src/components/home/ProofOfWork.vue
+++ b/src/components/home/ProofOfWork.vue
@@ -88,7 +88,7 @@ const { data: raw } = useFetch<{ status: string; data: SignalData }>('/api/signa
 
 const signal = computed(() => raw.value?.data)
 
-const heatColors = ['var(--void-panel)', '#0e4429', '#006d32', '#26a641', 'var(--nw-green)']
+const heatColors = ['var(--void-panel)', 'var(--nw-primary-fill)', 'rgba(68,119,204,0.45)', 'var(--nw-primary-dim)', 'var(--nw-primary)']
 
 function formatNumber(n: number | undefined): string {
   if (n == null) return '...'

--- a/src/components/home/ProofOfWork.vue
+++ b/src/components/home/ProofOfWork.vue
@@ -1,0 +1,116 @@
+<template>
+  <div class="panel reveal">
+    <div class="panel-header">
+      <span>SIGNAL · PROOF OF WORK</span>
+      <span class="text-nw-green font-stamp uppercase tracking-wider text-[10px]">LIVE</span>
+    </div>
+
+    <!-- GitHub Heatmap -->
+    <div class="px-5 py-4 flex items-center gap-6 border-b border-nw-text-faint">
+      <div v-if="signal?.github.weeks.length" class="heatmap-grid shrink-0">
+        <div v-for="(week, wi) in signal.github.weeks" :key="wi" class="heatmap-col">
+          <div
+            v-for="(level, di) in week"
+            :key="di"
+            class="heatmap-cell"
+            :style="{ background: heatColors[level] || heatColors[0] }"
+          />
+        </div>
+      </div>
+      <div v-else class="w-[200px] h-[84px] bg-void-panel" />
+      <div class="font-stamp uppercase tracking-wider text-[9px] text-nw-text-dim leading-loose whitespace-nowrap">
+        <span class="text-nw-green font-bold text-xs">{{ signal?.github.contributions ?? '...' }}</span> contributions<br>
+        <span class="text-nw-cyan font-bold text-xs">{{ signal?.github.publicRepos ?? '...' }}</span> public repos<br>
+        <span class="text-nw-purple font-bold text-xs">3</span> npm packages
+      </div>
+    </div>
+
+    <!-- Metrics strip -->
+    <div class="metrics-grid grid grid-cols-2 md:grid-cols-5">
+      <div class="metric-cell">
+        <div class="m-label">CONTAINERS</div>
+        <div class="m-value">16</div>
+      </div>
+      <div class="metric-cell">
+        <div class="m-label">NPM DL / MO</div>
+        <div class="m-value" style="color: var(--nw-purple); text-shadow: 0 0 6px rgba(187,154,247,0.3);">
+          {{ formatNumber(signal?.npm.total) }}
+        </div>
+      </div>
+      <div class="metric-cell">
+        <div class="m-label">LUMIRA</div>
+        <div class="m-value" style="color: var(--nw-cyan); text-shadow: 0 0 6px rgba(125,207,255,0.3);">
+          {{ formatNumber(signal?.npm.lumira) }}
+        </div>
+        <div class="m-sub">downloads / mo</div>
+      </div>
+      <div class="metric-cell">
+        <div class="m-label">API VERSION</div>
+        <div class="m-value" style="font-size: 16px;">
+          {{ signal ? `v${signal.api.version}` : '...' }}
+        </div>
+      </div>
+      <div class="metric-cell">
+        <div class="m-label">API STATUS</div>
+        <div class="m-value" style="font-size: 14px;">
+          <span class="led blink" :class="signal?.api.status === 'operational' ? 'green' : 'red'" style="display: inline-block;" />
+        </div>
+      </div>
+    </div>
+
+    <!-- Terminal one-liner -->
+    <div class="px-5 py-3 border-t border-nw-text-faint font-sys text-[11px] text-nw-text-dim leading-relaxed">
+      <span class="text-nw-green">$</span>
+      <span> curl </span>
+      <span class="text-nw-cyan">api.cativo.dev</span>
+      <span> → </span>
+      <span class="text-nw-green">"{{ signal?.api.status ?? '...' }}"</span>
+      <span> · </span>
+      <span class="text-nw-yellow">16</span>
+      <span> containers · </span>
+      <span class="text-nw-yellow">6</span>
+      <span> stacks</span>
+      <span class="inline-block w-[7px] h-[13px] bg-nw-green align-text-bottom" style="animation: nw-caret-blink 1s steps(2) infinite;" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface SignalData {
+  github: { contributions: number; weeks: number[][]; publicRepos: number }
+  npm: { lumira: number; claudeSetup: number; nightwire: number; total: number }
+  api: { version: string; status: string }
+}
+
+const { data: raw } = useFetch<{ status: string; data: SignalData }>('/api/signal', {
+  server: false,
+})
+
+const signal = computed(() => raw.value?.data)
+
+const heatColors = ['var(--void-panel)', '#0e4429', '#006d32', '#26a641', 'var(--nw-green)']
+
+function formatNumber(n: number | undefined): string {
+  if (n == null) return '...'
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}K`
+  return String(n)
+}
+</script>
+
+<style scoped>
+.heatmap-grid {
+  display: flex;
+  gap: 2px;
+  overflow: hidden;
+}
+.heatmap-col {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.heatmap-cell {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+}
+</style>

--- a/src/components/home/portfolio/FeatureProjectCard.vue
+++ b/src/components/home/portfolio/FeatureProjectCard.vue
@@ -1,16 +1,20 @@
 <template>
   <NuxtLink
     :to="`/projects/${project.id}`"
-    class="bg-void-raised hover:bg-void-panel border border-nw-text-line hover:border-nw-primary-dim transition-colors duration-150 p-5 flex flex-col gap-3"
+    :class="[
+      'bg-void-raised hover:bg-void-panel border hover:border-nw-primary-dim transition-all duration-200 p-5 flex flex-col gap-3',
+      featured ? 'border-nw-primary-dim/50' : 'border-nw-text-line',
+      'hover:-translate-y-0.5 hover:shadow-[0_4px_20px_rgba(102,153,255,0.08)]',
+    ]"
   >
     <header class="flex items-start justify-between gap-3">
       <div>
         <div class="font-stamp uppercase tracking-[0.14em] text-[9px] text-nw-text-dim">
           CASE-{{ String(project.id).padStart(4, '0') }}
         </div>
-        <h4 class="compressed-title title-card text-nw-text mt-1">
+        <component :is="featured ? 'h3' : 'h4'" class="compressed-title text-nw-text mt-1" :class="featured ? 'title-card-lg' : 'title-card'">
           {{ project.title }}
-        </h4>
+        </component>
       </div>
       <span v-if="project.status" class="badge" :class="badgeClass">
         {{ project.status }}
@@ -44,9 +48,12 @@ import type { Project } from '~/types/project'
 
 interface Props {
   project: Project & { createdAt?: string; status?: string }
+  featured?: boolean
 }
 
-const props = defineProps<Props>()
+const props = withDefaults(defineProps<Props>(), {
+  featured: false,
+})
 
 defineOptions({ name: 'FeatureProjectCard' })
 

--- a/src/components/home/portfolio/PortfolioSection.vue
+++ b/src/components/home/portfolio/PortfolioSection.vue
@@ -28,9 +28,12 @@
       <!-- Projects -->
       <FeatureProjectCard
         v-else
-        v-for="project in (data as any).data"
+        v-for="(project, index) in (data as any).data"
         :key="project.id || project.title"
         :project="project"
+        :class="[index === 0 ? 'md:col-span-2' : '', 'reveal']"
+        :style="{ '--delay': `${index * 0.08}s` }"
+        :featured="index === 0"
       />
     </div>
   </div>

--- a/src/components/home/portfolio/PortfolioSection.vue
+++ b/src/components/home/portfolio/PortfolioSection.vue
@@ -31,8 +31,7 @@
         v-for="(project, index) in (data as any).data"
         :key="project.id || project.title"
         :project="project"
-        :class="[index === 0 ? 'md:col-span-2' : '', 'reveal']"
-        :style="{ '--delay': `${index * 0.08}s` }"
+        :class="[index === 0 ? 'md:col-span-2' : '']"
         :featured="index === 0"
       />
     </div>

--- a/src/components/home/portfolio/PortfolioSection.vue
+++ b/src/components/home/portfolio/PortfolioSection.vue
@@ -47,6 +47,5 @@ const { data, pending, error: fetchError } = await useFetch('/api/projects', {
   query: { is_featured: 'true' },
   lazy: false,
   server: true,
-  getCachedData: () => undefined,
 })
 </script>

--- a/src/pages/about.vue
+++ b/src/pages/about.vue
@@ -305,10 +305,12 @@ const summaryParagraphs = computed(() => {
   return profile.summary;
 });
 
+// Safe: input is hardcoded profile.summary above, never from external/user sources
 function formatSummaryParagraph(text: string) {
-  return text
+  const escaped = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  return escaped
     .replace(/(9 years)/g, '<span class="text-nw-cyan font-semibold">$1</span>')
     .replace(/(sofIA|VittBot|Clarify)/g, '<span class="text-nw-purple font-medium">$1</span>')
-    .replace(/(Visa ISO 8583|Invoice Service|FEL|cativo\.dev)/g, '<span class="text-nw-primary font-medium">$1</span>');
+    .replace(/(Visa ISO 8583|Invoice Service|FEL|cativo\.dev)/g, '<span class="text-nw-primary font-medium">$1</span>')
 }
 </script>

--- a/src/pages/about.vue
+++ b/src/pages/about.vue
@@ -246,7 +246,7 @@ const profile: Profile = {
     {
       role: 'B.Sc. Computer Systems Engineering',
       company: 'Universidad de El Salvador',
-      period: '2014 – 2021',
+      period: '2023',
       location: 'Education',
       description: "Specialization in Cloud Infrastructure.",
       tags: []

--- a/src/pages/contact.vue
+++ b/src/pages/contact.vue
@@ -1,131 +1,131 @@
 <template>
-  <div>
-    <h2 class="compressed-title text-nw-3xl text-nw-cyan mb-2">
-      Get in touch.
-    </h2>
-    <p class="text-nw-text-dim mb-2 max-w-2xl">
-      Best for hiring managers, recruiters, and engineers who want to talk shop. I read every message — fastest reply via email or LinkedIn.
-    </p>
-    <p class="text-meta mb-8 max-w-2xl">
-      Open to senior backend / tech lead / staff roles. Remote-first, open to relocation for the right role with sponsorship.
-    </p>
-
-    <!-- Direct channels -->
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-3 mb-8">
-      <a href="mailto:cativo@cativo.dev"
-         class="bg-void-panel border border-nw-text-faint hover:border-nw-primary-dim p-4 transition-colors">
-        <div class="font-stamp uppercase tracking-wider text-[10px] text-nw-text-dim mb-1">EMAIL</div>
-        <div class="text-meta text-nw-primary font-mono">cativo@cativo.dev</div>
-      </a>
-      <a href="https://linkedin.com/in/carlos-cativo" target="_blank" rel="noopener noreferrer"
-         class="bg-void-panel border border-nw-text-faint hover:border-nw-primary-dim p-4 transition-colors">
-        <div class="font-stamp uppercase tracking-wider text-[10px] text-nw-text-dim mb-1">LINKEDIN</div>
-        <div class="text-meta text-nw-primary font-mono">/in/carlos-cativo →</div>
-      </a>
-      <a href="/resume.pdf" download="cativo-cv.pdf"
-         class="bg-void-panel border border-nw-text-faint hover:border-nw-primary-dim p-4 transition-colors">
-        <div class="font-stamp uppercase tracking-wider text-[10px] text-nw-text-dim mb-1">CV / RESUME</div>
-        <div class="text-meta text-nw-primary font-mono">↓ Download PDF</div>
-      </a>
+  <div class="space-y-2 pb-16">
+    <!-- HEADER -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>OPEN CHANNEL</span>
+      </div>
+      <div class="panel-body p-6 lg:p-8">
+        <h1 class="compressed-title text-nw-text leading-[1.05] mb-3" style="font-size: clamp(32px, 6vw, 52px);">
+          Get in <span class="text-nw-primary">touch.</span>
+        </h1>
+        <p class="text-nw-text-dim leading-relaxed mb-2 max-w-2xl">
+          Best for hiring managers, recruiters, and engineers who want to talk shop. I read every message — fastest reply via email or LinkedIn.
+        </p>
+        <p class="text-meta max-w-2xl">
+          Open to senior backend / tech lead / staff roles. Remote-first, open to relocation for the right role with sponsorship.
+        </p>
+      </div>
     </div>
 
-    <p class="text-meta text-nw-text-dim font-stamp uppercase tracking-wider mb-4">
-      Or send a message below · Calendly: <a href="https://calendly.com/cativo23" target="_blank" rel="noopener noreferrer" class="text-nw-primary hover:text-nw-primary-hot normal-case tracking-normal">book 30 min →</a>
-    </p>
-
-    <!-- Success State -->
-    <div v-if="successMessage" class="bg-nw-green/10 border border-nw-green/30 rounded p-6 text-center" role="status">
-      <LucideCheckCircle class="w-12 h-12 text-nw-green mx-auto mb-3" />
-      <p class="text-nw-green font-stamp uppercase tracking-wide font-bold mb-2">Message Sent!</p>
-      <p class="text-nw-text-dim">{{ successMessage }}</p>
-      <button @click="successMessage = null" class="mt-4 text-meta text-nw-cyan font-sys underline hover:text-nw-primary transition">
-        Send another message
-      </button>
+    <!-- DIRECT CHANNELS -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>DIRECT CHANNELS</span>
+      </div>
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-px bg-nw-text-faint">
+        <a href="mailto:cativo@cativo.dev"
+           class="bg-void-warm hover:bg-void-panel p-5 transition-colors">
+          <div class="font-stamp uppercase tracking-wider text-[10px] text-nw-text-dim mb-1">EMAIL</div>
+          <div class="text-meta text-nw-primary font-sys">cativo@cativo.dev</div>
+        </a>
+        <a href="https://linkedin.com/in/carlos-cativo" target="_blank" rel="noopener noreferrer"
+           class="bg-void-warm hover:bg-void-panel p-5 transition-colors">
+          <div class="font-stamp uppercase tracking-wider text-[10px] text-nw-text-dim mb-1">LINKEDIN</div>
+          <div class="text-meta text-nw-primary font-sys">/in/carlos-cativo →</div>
+        </a>
+        <a href="/resume.pdf" download="cativo-cv.pdf"
+           class="bg-void-warm hover:bg-void-panel p-5 transition-colors">
+          <div class="font-stamp uppercase tracking-wider text-[10px] text-nw-text-dim mb-1">CV / RESUME</div>
+          <div class="text-meta text-nw-primary font-sys">↓ Download PDF</div>
+        </a>
+      </div>
     </div>
 
-    <!-- Form -->
-    <form v-else @submit.prevent="submitForm" class="bg-void-warm border border-nw-text-line/30 p-6 rounded flex flex-col gap-4 w-full" novalidate>
-      <div class="flex flex-col gap-1">
-        <label for="name" class="text-nw-cyan font-stamp uppercase tracking-wide font-bold">Name</label>
-        <input
-          type="text"
-          id="name"
-          v-model="form.name"
-          @blur="validateField('name')"
-          :aria-invalid="fieldErrors.name ? 'true' : 'false'"
-          :aria-describedby="fieldErrors.name ? 'name-error' : undefined"
-          required
-          autocomplete="name"
-          class="w-full px-3 py-2 bg-void-warm text-nw-text border rounded focus:outline-none focus:ring-2 focus:ring-nw-cyan font-sys placeholder-nw-text-dim transition"
-          :class="fieldErrors.name ? 'border-red-400' : 'border-nw-text-line'"
-          placeholder="Your name"
-        >
-        <p v-if="fieldErrors.name" id="name-error" class="text-meta text-red-400 font-sys mt-1" role="alert">
-          {{ fieldErrors.name }}
-        </p>
+    <!-- MESSAGE FORM -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>SEND A MESSAGE</span>
+        <a href="https://calendly.com/cativo23" target="_blank" rel="noopener noreferrer"
+           class="text-nw-primary hover:text-nw-primary-hot text-[10px] font-stamp uppercase tracking-wider">
+          OR BOOK 30 MIN →
+        </a>
       </div>
+      <div class="panel-body p-6 lg:p-8">
+        <!-- Success State -->
+        <div v-if="successMessage" class="bg-nw-green/10 border border-nw-green/30 p-6 text-center" role="status">
+          <p class="text-nw-green font-stamp uppercase tracking-wide font-bold mb-2">Message Sent!</p>
+          <p class="text-meta">{{ successMessage }}</p>
+          <BaseButton variant="ghost" class="mt-4" @click="successMessage = null">
+            Send another message
+          </BaseButton>
+        </div>
 
-      <div class="flex flex-col gap-1">
-        <label for="email" class="text-nw-cyan font-stamp uppercase tracking-wide font-bold">Email</label>
-        <input
-          type="email"
-          id="email"
-          v-model="form.email"
-          @blur="validateField('email')"
-          :aria-invalid="fieldErrors.email ? 'true' : 'false'"
-          :aria-describedby="fieldErrors.email ? 'email-error' : undefined"
-          required
-          autocomplete="email"
-          class="w-full px-3 py-2 bg-void-warm text-nw-text border rounded focus:outline-none focus:ring-2 focus:ring-nw-cyan font-sys placeholder-nw-text-dim transition"
-          :class="fieldErrors.email ? 'border-red-400' : 'border-nw-text-line'"
-          placeholder="you@email.com"
-        >
-        <p v-if="fieldErrors.email" id="email-error" class="text-meta text-red-400 font-sys mt-1" role="alert">
-          {{ fieldErrors.email }}
-        </p>
+        <!-- Form -->
+        <form v-else @submit.prevent="submitForm" class="max-w-xl flex flex-col gap-4" novalidate>
+          <div class="flex flex-col gap-1">
+            <label for="name" class="text-nw-cyan font-stamp uppercase tracking-wide text-[11px]">NAME</label>
+            <input
+              type="text" id="name" v-model="form.name"
+              @blur="validateField('name')"
+              :aria-invalid="fieldErrors.name ? 'true' : 'false'"
+              :aria-describedby="fieldErrors.name ? 'name-error' : undefined"
+              required autocomplete="name"
+              class="w-full px-3 py-2 bg-void text-nw-text border focus:outline-none focus:ring-2 focus:ring-nw-cyan font-sys placeholder-nw-text-dim transition"
+              :class="fieldErrors.name ? 'border-nw-red' : 'border-nw-text-line'"
+              placeholder="Your name"
+            >
+            <p v-if="fieldErrors.name" id="name-error" class="text-meta text-nw-red mt-1" role="alert">
+              {{ fieldErrors.name }}
+            </p>
+          </div>
+
+          <div class="flex flex-col gap-1">
+            <label for="email" class="text-nw-cyan font-stamp uppercase tracking-wide text-[11px]">EMAIL</label>
+            <input
+              type="email" id="email" v-model="form.email"
+              @blur="validateField('email')"
+              :aria-invalid="fieldErrors.email ? 'true' : 'false'"
+              :aria-describedby="fieldErrors.email ? 'email-error' : undefined"
+              required autocomplete="email"
+              class="w-full px-3 py-2 bg-void text-nw-text border focus:outline-none focus:ring-2 focus:ring-nw-cyan font-sys placeholder-nw-text-dim transition"
+              :class="fieldErrors.email ? 'border-nw-red' : 'border-nw-text-line'"
+              placeholder="you@email.com"
+            >
+            <p v-if="fieldErrors.email" id="email-error" class="text-meta text-nw-red mt-1" role="alert">
+              {{ fieldErrors.email }}
+            </p>
+          </div>
+
+          <div class="flex flex-col gap-1">
+            <label for="message" class="text-nw-cyan font-stamp uppercase tracking-wide text-[11px]">MESSAGE</label>
+            <textarea
+              id="message" v-model="form.message"
+              @blur="validateField('message')"
+              :aria-invalid="fieldErrors.message ? 'true' : 'false'"
+              :aria-describedby="fieldErrors.message ? 'message-error' : undefined"
+              required rows="4"
+              class="w-full px-3 py-2 bg-void text-nw-text border focus:outline-none focus:ring-2 focus:ring-nw-cyan font-sys placeholder-nw-text-dim transition resize-y"
+              :class="fieldErrors.message ? 'border-nw-red' : 'border-nw-text-line'"
+              placeholder="Type your message..."
+            ></textarea>
+            <p v-if="fieldErrors.message" id="message-error" class="text-meta text-nw-red mt-1" role="alert">
+              {{ fieldErrors.message }}
+            </p>
+          </div>
+
+          <!-- Honeypot -->
+          <input type="text" v-model="form.website" tabindex="-1" autocomplete="off"
+            class="absolute -left-[9999px] -top-[9999px] opacity-0 h-0 w-0 overflow-hidden" aria-hidden="true">
+
+          <div v-if="error" class="text-meta text-nw-red" role="alert">{{ error }}</div>
+
+          <BaseButton type="submit" :loading="loading" :disabled="loading" variant="primary">
+            {{ loading ? 'Sending...' : 'Send message' }}
+          </BaseButton>
+        </form>
       </div>
-
-      <div class="flex flex-col gap-1">
-        <label for="message" class="text-nw-cyan font-stamp uppercase tracking-wide font-bold">Message</label>
-        <textarea
-          id="message"
-          v-model="form.message"
-          @blur="validateField('message')"
-          :aria-invalid="fieldErrors.message ? 'true' : 'false'"
-          :aria-describedby="fieldErrors.message ? 'message-error' : undefined"
-          required
-          rows="4"
-          class="w-full px-3 py-2 bg-void-warm text-nw-text border rounded focus:outline-none focus:ring-2 focus:ring-nw-cyan font-sys placeholder-nw-text-dim transition"
-          :class="fieldErrors.message ? 'border-red-400' : 'border-nw-text-line'"
-          placeholder="Type your message..."
-        ></textarea>
-        <p v-if="fieldErrors.message" id="message-error" class="text-meta text-red-400 font-sys mt-1" role="alert">
-          {{ fieldErrors.message }}
-        </p>
-      </div>
-
-      <!-- Honeypot field - hidden from real users, catches bots -->
-      <input
-        type="text"
-        id="website"
-        v-model="form.website"
-        tabindex="-1"
-        autocomplete="off"
-        class="absolute -left-[9999px] -top-[9999px] opacity-0 h-0 w-0 overflow-hidden"
-        aria-hidden="true"
-      >
-
-      <div v-if="error" class="text-meta text-red-400 font-sys" role="alert">{{ error }}</div>
-
-      <button
-        :disabled="loading"
-        type="submit"
-        class="mt-2 px-6 py-2 bg-void-raised text-void-warm font-sys font-bold rounded shadow hover:bg-nw-cyan transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
-      >
-        <LucideLoader v-if="loading" class="w-4 h-4 animate-spin" />
-        {{ loading ? 'Sending...' : 'Send Message' }}
-      </button>
-    </form>
+    </div>
   </div>
 </template>
 
@@ -133,7 +133,7 @@
 import { ref, reactive } from 'vue';
 
 usePageTitle('Contact', {
-  description: 'Get in touch with me! I am always open to discussing new projects, creative ideas, or opportunities to be part of your vision.'
+  description: 'Get in touch with Carlos Cativo — senior backend engineer and tech lead. Open to remote roles.',
 });
 
 interface ContactForm {
@@ -200,10 +200,7 @@ function validateForm(): boolean {
 }
 
 async function submitForm() {
-  // Honeypot check — bots often fill hidden "website" fields
-  if (form.website) {
-    return;
-  }
+  if (form.website) return;
 
   if (!validateForm()) {
     error.value = 'Please fix the errors above.';

--- a/src/pages/cv.vue
+++ b/src/pages/cv.vue
@@ -181,7 +181,7 @@ const print = () => {
       <section>
         <h2>Education</h2>
         <p>
-          <strong>Universidad de El Salvador</strong> — Engineer's degree, Computer Engineering (2014 — 2021).
+          <strong>Universidad de El Salvador</strong> — B.Sc. Computer Systems Engineering, 2023. Specialization in Cloud Infrastructure.
         </p>
       </section>
     </main>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -2,6 +2,9 @@
   <div class="space-y-0.5">
     <Hero />
 
+    <!-- PROOF OF WORK -->
+    <ProofOfWork />
+
     <!-- AT A GLANCE -->
     <div class="panel">
       <div class="panel-header">
@@ -47,6 +50,7 @@ import Contact from '@/components/home/Contact.vue';
 import Hero from '@/components/home/Hero.vue';
 import LatestPosts from '@/components/home/LatestPosts.vue';
 import PortfolioSection from '@/components/home/portfolio/PortfolioSection.vue';
+import ProofOfWork from '@/components/home/ProofOfWork.vue';
 
 usePageTitle('Home', {
   description: 'Carlos Cativo - Tech Lead & Full-Stack Software Engineer. 9 years building healthcare platforms, payment systems, and AI-powered products.',

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -5,35 +5,6 @@
     <!-- PROOF OF WORK -->
     <ProofOfWork />
 
-    <!-- AT A GLANCE -->
-    <div class="panel">
-      <div class="panel-header">
-        <span>AT A GLANCE</span>
-      </div>
-      <div class="metrics-grid grid grid-cols-2 md:grid-cols-4">
-        <div class="metric-cell">
-          <div class="m-label">YEARS IN PRODUCTION</div>
-          <div class="m-value">9</div>
-          <div class="m-sub">backend since 2016</div>
-        </div>
-        <div class="metric-cell">
-          <div class="m-label">CURRENT ROLE</div>
-          <div class="m-value" style="font-size: 16px;">TECH LEAD</div>
-          <div class="m-sub">3+ yrs · Blue Medical Guatemala</div>
-        </div>
-        <div class="metric-cell highlight">
-          <div class="m-label">SPECIALTY</div>
-          <div class="m-value" style="font-size: 13px;">PAYMENTS · FEL · INTEGRATIONS</div>
-          <div class="m-sub">ISO 8583 · multi-gateway · multi-provider</div>
-        </div>
-        <div class="metric-cell">
-          <div class="m-label">SELF-HOSTED</div>
-          <div class="m-value">16</div>
-          <div class="m-sub">containers · cativo.dev</div>
-        </div>
-      </div>
-    </div>
-
     <!-- FEATURED CASE FILES -->
     <PortfolioSection />
 

--- a/src/plugins/reveal.client.ts
+++ b/src/plugins/reveal.client.ts
@@ -1,0 +1,24 @@
+export default defineNuxtPlugin((nuxtApp) => {
+  if (typeof window === 'undefined') return
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('is-visible')
+          observer.unobserve(entry.target)
+        }
+      })
+    },
+    { threshold: 0.1 }
+  )
+
+  function scan() {
+    document.querySelectorAll('.reveal:not(.is-visible)').forEach((el) => {
+      observer.observe(el)
+    })
+  }
+
+  nuxtApp.hook('page:transition:finish', scan)
+  scan()
+})

--- a/src/server/api/blog/latest.get.ts
+++ b/src/server/api/blog/latest.get.ts
@@ -50,7 +50,9 @@ async function fetchLatest(): Promise<BlogPost[]> {
     const url = pickFirst(raw, 'link')
     const pubDate = pickFirst(raw, 'pubDate')
     const rawDesc = pickFirst(raw, 'description')
-    const description = stripHtml(rawDesc).slice(0, 200)
+    const clean = stripHtml(rawDesc)
+    const cut = clean.slice(0, 140)
+    const description = cut.includes(' ') ? cut.slice(0, cut.lastIndexOf(' ')) + '...' : cut
     return { title, url, pubDate, description }
   })
 }

--- a/src/server/api/profile.get.ts
+++ b/src/server/api/profile.get.ts
@@ -66,7 +66,7 @@ export default defineEventHandler(async () => {
           {
             role: 'B.Sc. Computer Systems Engineering',
             company: 'Universidad de El Salvador',
-            period: '2014 – 2021',
+            period: '2023',
             location: 'Education',
             description: "Specialization in Cloud Infrastructure.",
             tags: []

--- a/src/server/api/signal.get.ts
+++ b/src/server/api/signal.get.ts
@@ -1,0 +1,136 @@
+interface SignalData {
+  github: {
+    contributions: number
+    weeks: number[][]
+    publicRepos: number
+  }
+  npm: {
+    lumira: number
+    claudeSetup: number
+    nightwire: number
+    total: number
+  }
+  api: {
+    version: string
+    status: string
+  }
+}
+
+async function fetchGitHubContributions(token: string): Promise<{ contributions: number; weeks: number[][] }> {
+  if (!token) {
+    return { contributions: 0, weeks: [] }
+  }
+
+  const query = `query {
+    user(login: "cativo23") {
+      contributionsCollection {
+        contributionCalendar {
+          totalContributions
+          weeks {
+            contributionDays {
+              contributionCount
+              contributionLevel
+            }
+          }
+        }
+      }
+    }
+  }`
+
+  const res = await $fetch<any>('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: { query },
+    timeout: 8000,
+  })
+
+  const calendar = res?.data?.user?.contributionsCollection?.contributionCalendar
+  if (!calendar) return { contributions: 0, weeks: [] }
+
+  const levelMap: Record<string, number> = {
+    NONE: 0,
+    FIRST_QUARTILE: 1,
+    SECOND_QUARTILE: 2,
+    THIRD_QUARTILE: 3,
+    FOURTH_QUARTILE: 4,
+  }
+
+  const weeks = calendar.weeks.slice(-16).map((w: any) =>
+    w.contributionDays.map((d: any) => levelMap[d.contributionLevel] ?? 0)
+  )
+
+  return {
+    contributions: calendar.totalContributions,
+    weeks,
+  }
+}
+
+async function fetchGitHubRepos(token: string): Promise<number> {
+  const headers: Record<string, string> = token
+    ? { Authorization: `Bearer ${token}` }
+    : {}
+  const res = await $fetch<any>('https://api.github.com/users/cativo23', { timeout: 5000, headers })
+  return res?.public_repos ?? 0
+}
+
+async function fetchNpmDownloads(pkg: string): Promise<number> {
+  const res = await $fetch<any>(
+    `https://api.npmjs.org/downloads/point/last-month/${pkg}`,
+    { timeout: 5000 }
+  )
+  return res?.downloads ?? 0
+}
+
+async function fetchApiHealth(): Promise<{ version: string; status: string }> {
+  try {
+    const res = await $fetch<any>('https://api.cativo.dev', { timeout: 5000 })
+    return {
+      version: res?.data?.version ?? '...',
+      status: res?.data?.status ?? 'unknown',
+    }
+  } catch {
+    return { version: '...', status: 'unreachable' }
+  }
+}
+
+export default defineCachedEventHandler(
+  async (event) => {
+    const { githubToken } = useRuntimeConfig(event)
+    const [gh, repos, lumira, claudeSetup, nightwire, api] = await Promise.allSettled([
+      fetchGitHubContributions(githubToken),
+      fetchGitHubRepos(githubToken),
+      fetchNpmDownloads('lumira'),
+      fetchNpmDownloads('claude-setup'),
+      fetchNpmDownloads('@cativo23/nightwire'),
+      fetchApiHealth(),
+    ])
+
+    const ghData = gh.status === 'fulfilled' ? gh.value : { contributions: 0, weeks: [] }
+    const repoCount = repos.status === 'fulfilled' ? repos.value : 0
+    const lumiraDl = lumira.status === 'fulfilled' ? lumira.value : 0
+    const claudeSetupDl = claudeSetup.status === 'fulfilled' ? claudeSetup.value : 0
+    const nightwireDl = nightwire.status === 'fulfilled' ? nightwire.value : 0
+    const apiData = api.status === 'fulfilled' ? api.value : { version: '...', status: 'unknown' }
+
+    const data: SignalData = {
+      github: {
+        contributions: ghData.contributions,
+        weeks: ghData.weeks,
+        publicRepos: repoCount,
+      },
+      npm: {
+        lumira: lumiraDl,
+        claudeSetup: claudeSetupDl,
+        nightwire: nightwireDl,
+        total: lumiraDl + claudeSetupDl + nightwireDl,
+      },
+      api: apiData,
+    }
+
+    return { status: 'success', data }
+  },
+  { maxAge: 60 * 60 }
+)

--- a/src/server/api/signal.get.ts
+++ b/src/server/api/signal.get.ts
@@ -1,3 +1,8 @@
+interface NpmPackageData {
+  monthly: number
+  weekly: number[]
+}
+
 interface SignalData {
   github: {
     contributions: number
@@ -5,9 +10,9 @@ interface SignalData {
     publicRepos: number
   }
   npm: {
-    lumira: number
-    claudeSetup: number
-    nightwire: number
+    lumira: NpmPackageData
+    claudeSetup: NpmPackageData
+    nightwire: NpmPackageData
     total: number
   }
   api: {
@@ -58,7 +63,7 @@ async function fetchGitHubContributions(token: string): Promise<{ contributions:
     FOURTH_QUARTILE: 4,
   }
 
-  const weeks = calendar.weeks.slice(-16).map((w: any) =>
+  const weeks = calendar.weeks.slice(-30).map((w: any) =>
     w.contributionDays.map((d: any) => levelMap[d.contributionLevel] ?? 0)
   )
 
@@ -76,12 +81,29 @@ async function fetchGitHubRepos(token: string): Promise<number> {
   return res?.public_repos ?? 0
 }
 
-async function fetchNpmDownloads(pkg: string): Promise<number> {
-  const res = await $fetch<any>(
-    `https://api.npmjs.org/downloads/point/last-month/${pkg}`,
-    { timeout: 5000 }
-  )
-  return res?.downloads ?? 0
+async function fetchNpmDownloads(pkg: string): Promise<NpmPackageData> {
+  const end = new Date()
+  const start = new Date(end.getTime() - 7 * 7 * 24 * 60 * 60 * 1000) // 7 weeks ago
+  const fmt = (d: Date) => d.toISOString().slice(0, 10)
+
+  const [point, range] = await Promise.allSettled([
+    $fetch<any>(`https://api.npmjs.org/downloads/point/last-month/${pkg}`, { timeout: 5000 }),
+    $fetch<any>(`https://api.npmjs.org/downloads/range/${fmt(start)}:${fmt(end)}/${pkg}`, { timeout: 5000 }),
+  ])
+
+  const monthly = point.status === 'fulfilled' ? (point.value?.downloads ?? 0) : 0
+
+  let weekly: number[] = []
+  if (range.status === 'fulfilled' && range.value?.downloads) {
+    const days: { downloads: number }[] = range.value.downloads
+    for (let i = 0; i < days.length; i += 7) {
+      const chunk = days.slice(i, i + 7)
+      weekly.push(chunk.reduce((sum, d) => sum + d.downloads, 0))
+    }
+  }
+  if (weekly.length === 0) weekly = [0, 0, 0, 0, 0, 0, 0]
+
+  return { monthly, weekly }
 }
 
 async function fetchApiHealth(): Promise<{ version: string; status: string }> {
@@ -110,9 +132,10 @@ export default defineCachedEventHandler(
 
     const ghData = gh.status === 'fulfilled' ? gh.value : { contributions: 0, weeks: [] }
     const repoCount = repos.status === 'fulfilled' ? repos.value : 0
-    const lumiraDl = lumira.status === 'fulfilled' ? lumira.value : 0
-    const claudeSetupDl = claudeSetup.status === 'fulfilled' ? claudeSetup.value : 0
-    const nightwireDl = nightwire.status === 'fulfilled' ? nightwire.value : 0
+    const fallbackPkg: NpmPackageData = { monthly: 0, weekly: [0, 0, 0, 0, 0, 0, 0] }
+    const lumiraDl = lumira.status === 'fulfilled' ? lumira.value : fallbackPkg
+    const claudeSetupDl = claudeSetup.status === 'fulfilled' ? claudeSetup.value : fallbackPkg
+    const nightwireDl = nightwire.status === 'fulfilled' ? nightwire.value : fallbackPkg
     const apiData = api.status === 'fulfilled' ? api.value : { version: '...', status: 'unknown' }
 
     const data: SignalData = {
@@ -125,7 +148,7 @@ export default defineCachedEventHandler(
         lumira: lumiraDl,
         claudeSetup: claudeSetupDl,
         nightwire: nightwireDl,
-        total: lumiraDl + claudeSetupDl + nightwireDl,
+        total: lumiraDl.monthly + claudeSetupDl.monthly + nightwireDl.monthly,
       },
       api: apiData,
     }


### PR DESCRIPTION
## Summary

- **Proof of Work panel** — live GitHub contribution heatmap (GraphQL), NPM download stats, API health. Server-cached 1h via `/api/signal`. Dynamic LED (green/red) based on actual API status.
- **Scroll-triggered stagger fade-in** — CSS `.reveal` class + Nuxt `page:transition:finish` plugin with `IntersectionObserver`.
- **Featured project card hierarchy** — first card spans 2 columns with hover lift + accent border + `title-card-lg` token.
- **Contact page** — full rewrite to Nightwire panels (OPEN CHANNEL header, DIRECT CHANNELS grid, SEND A MESSAGE form).
- **Contact home component** — wrapped in panel with `OPEN CHANNEL · DIRECT LINE` header, `max-w-xl` form.
- **Nightwire consistency fixes** — GPU hints on compressed-title, Hero section wrapper removed, Timeline prose to text-meta, blog truncation at word boundary, v-html escaped, all GitHub API calls authenticated.

## Security

- `githubToken` is server-only (`runtimeConfig`, not `runtimeConfig.public`) — never exposed to client
- `v-html` in about.vue now HTML-escapes input before regex highlights
- All GitHub API calls use auth header to avoid 60 req/hr unauthenticated rate limit
- `/api/signal` response contains only public metrics — no tokens, no internal IPs

## Test plan

- [x] 244/244 unit tests pass
- [x] All routes 200 (/, /about, /now, /contact, /cv, /projects)
- [x] `/api/signal` returns real data (3117 contributions, 16 heatmap weeks, 2265 NPM dl/mo)
- [x] ProofOfWork renders heatmap with real GitHub data
- [x] Contact form submits correctly with Nightwire styling
- [x] Featured card spans 2 columns on desktop
- [x] Scroll reveal triggers on viewport entry
- [ ] CI passes