### PR TITLE
🚀 Release 1.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.10.2] - 2026-05-07
+
+### Fixed
+- **Prod healthcheck timeout** — Bumped `compose.prod.yml` healthcheck `timeout` 5s → 15s and `start_period` 10s → 30s. The home-page SSR now takes ~6s due to the POW signal data, which was causing every healthcheck to fail and Traefik to stop routing traffic (404s on cativo.dev).
+
+---
+
 ## [1.10.1] - 2026-05-07
 
 ### Fixed

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -11,8 +11,8 @@ services:
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://localhost:3000').then(r => { if (!r.ok) process.exit(1) }).catch(() => process.exit(1))"]
       interval: 30s
-      timeout: 5s
-      start_period: 10s
+      timeout: 15s
+      start_period: 30s
       retries: 3
     labels:
       - "traefik.enable=true"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-app",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
Hotfix shipped as a release branch (auto-release workflow only triggers on `release/*` — see follow-up note below).

cativo.dev returning 404 because the prod container is marked unhealthy. Home-page SSR now takes ~6s due to POW signal data, exceeding the 5s healthcheck timeout. Traefik stops routing to unhealthy backends.

## Fix
- `compose.prod.yml`: healthcheck `timeout` 5s → 15s, `start_period` 10s → 30s.

## Follow-up
- `auto-release.yml` filters `startsWith(head.ref, 'release/')`, contradicting the hotfix flow described in `AGENTS.md`. Either extend the filter to include `hotfix/*` or update the docs.

## Test plan
- [ ] Auto-release creates v1.10.2
- [ ] Deploy succeeds and container reaches `healthy`
- [ ] cativo.dev returns 200
- [ ] Merge main back to develop