### PR TITLE
🚀 Release 1.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.10.3] - 2026-05-07
+
+### Fixed
+- **POW signal token actually reaching Nuxt runtime** — Map the `POW_GH_TOKEN` repo secret onto `NUXT_GITHUB_TOKEN` (not `POW_GH_TOKEN`) inside the container. Nuxt runtime config only overrides `runtimeConfig.githubToken` from env vars matching the `NUXT_*` + key pattern; the previous mapping left the runtime token empty and the GitHub GraphQL call returning an early-fallback zero. POW heatmap now shows real contribution data.
+
+---
+
 ## [1.10.2] - 2026-05-07
 
 ### Fixed

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -7,7 +7,7 @@ services:
     environment:
       NODE_ENV: production
       PORT: 3000
-      POW_GH_TOKEN: ${POW_GH_TOKEN:?POW_GH_TOKEN is required}
+      NUXT_GITHUB_TOKEN: ${POW_GH_TOKEN:?POW_GH_TOKEN is required}
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://localhost:3000').then(r => { if (!r.ok) process.exit(1) }).catch(() => process.exit(1))"]
       interval: 30s

--- a/compose.yml
+++ b/compose.yml
@@ -15,7 +15,7 @@ services:
       NUXT_API_BASE_URL: http://host.docker.internal:3003
       NUXT_API_BASE_PATH: /api/v1
       NUXT_API_TOKEN: ${NUXT_API_TOKEN:-}
-      POW_GH_TOKEN: ${POW_GH_TOKEN:-}
+      NUXT_GITHUB_TOKEN: ${POW_GH_TOKEN:-}
     user: 'node'
     extra_hosts:
       - 'host.docker.internal:host-gateway'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-app",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
Make the POW token actually reach the Nuxt runtime so the GitHub GraphQL call in `/api/signal` authenticates and returns real contribution data.

## Fix
- `compose.prod.yml` and `compose.yml`: rename the env mapping inside the container from `POW_GH_TOKEN` to `NUXT_GITHUB_TOKEN` (still sourced from the `POW_GH_TOKEN` GH secret / server `.env`). Nuxt's `useRuntimeConfig()` overrides `runtimeConfig.githubToken` only from env vars matching the `NUXT_<KEY>` pattern.

## Verified in prod (in-place test on server)
- `/api/signal` now returns `contributions: 3169`, `weeks: 30`.
- Heatmap renders correctly on cativo.dev.

## Test plan
- [ ] Deploy succeeds, container reaches `healthy`
- [ ] cativo.dev `/api/signal` returns non-zero contributions
- [ ] Merge main back to develop