### PR TITLE
feat(spotify): add now playing widget

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,3 +113,6 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           POW_GH_TOKEN: ${{ secrets.POW_GH_TOKEN }}
+          SPOTIFY_CLIENT_ID: ${{ secrets.SPOTIFY_CLIENT_ID }}
+          SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIFY_CLIENT_SECRET }}
+          SPOTIFY_REFRESH_TOKEN: ${{ secrets.SPOTIFY_REFRESH_TOKEN }}

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -8,6 +8,9 @@ services:
       NODE_ENV: production
       PORT: 3000
       NUXT_GITHUB_TOKEN: ${POW_GH_TOKEN:?POW_GH_TOKEN is required}
+      SPOTIFY_CLIENT_ID: ${SPOTIFY_CLIENT_ID:-}
+      SPOTIFY_CLIENT_SECRET: ${SPOTIFY_CLIENT_SECRET:-}
+      SPOTIFY_REFRESH_TOKEN: ${SPOTIFY_REFRESH_TOKEN:-}
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://localhost:3000').then(r => { if (!r.ok) process.exit(1) }).catch(() => process.exit(1))"]
       interval: 30s

--- a/compose.yml
+++ b/compose.yml
@@ -16,6 +16,9 @@ services:
       NUXT_API_BASE_PATH: /api/v1
       NUXT_API_TOKEN: ${NUXT_API_TOKEN:-}
       NUXT_GITHUB_TOKEN: ${POW_GH_TOKEN:-}
+      SPOTIFY_CLIENT_ID: ${SPOTIFY_CLIENT_ID:-}
+      SPOTIFY_CLIENT_SECRET: ${SPOTIFY_CLIENT_SECRET:-}
+      SPOTIFY_REFRESH_TOKEN: ${SPOTIFY_REFRESH_TOKEN:-}
     user: 'node'
     extra_hosts:
       - 'host.docker.internal:host-gateway'

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -30,6 +30,9 @@ export default defineNuxtConfig({
     apiBasePath: process.env.NUXT_API_BASE_PATH || '/api/v1',
     apiToken: process.env.NUXT_API_TOKEN || '',
     githubToken: process.env.POW_GH_TOKEN || '',
+    spotifyClientId: process.env.SPOTIFY_CLIENT_ID || '',
+    spotifyClientSecret: process.env.SPOTIFY_CLIENT_SECRET || '',
+    spotifyRefreshToken: process.env.SPOTIFY_REFRESH_TOKEN || '',
     public: {
       baseTitle: 'Carlos Cativo',
       defaultOgImage: '/img/akira.jpeg',

--- a/scripts/spotify-token.mjs
+++ b/scripts/spotify-token.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * One-time script to get a Spotify refresh token.
+ *
+ * Usage:
+ *   node scripts/spotify-token.mjs <CLIENT_ID> <CLIENT_SECRET>
+ *
+ * Starts a local server on :8888, opens the Spotify auth page,
+ * and prints the refresh token after you authorize.
+ */
+
+import http from 'node:http';
+import { execFile } from 'node:child_process';
+import { URL, URLSearchParams } from 'node:url';
+
+const [clientId, clientSecret] = process.argv.slice(2);
+
+if (!clientId || !clientSecret) {
+  console.error('Usage: node scripts/spotify-token.mjs <CLIENT_ID> <CLIENT_SECRET>');
+  process.exit(1);
+}
+
+const PORT = 8888;
+const REDIRECT_URI = `http://127.0.0.1:${PORT}/callback`;
+const SCOPES = 'user-read-currently-playing user-read-playback-state';
+
+const authUrl = new URL('https://accounts.spotify.com/authorize');
+authUrl.searchParams.set('client_id', clientId);
+authUrl.searchParams.set('response_type', 'code');
+authUrl.searchParams.set('redirect_uri', REDIRECT_URI);
+authUrl.searchParams.set('scope', SCOPES);
+
+const authString = authUrl.toString();
+
+console.log('\n→ Opening Spotify authorization page...');
+console.log(`  If it doesn't open, go to:\n  ${authString}\n`);
+
+try {
+  execFile('xdg-open', [authString], () => {});
+} catch {
+  try { execFile('open', [authString], () => {}); } catch { /* best-effort */ }
+}
+
+const server = http.createServer(async (req, res) => {
+  if (!req.url?.startsWith('/callback')) return;
+
+  const url = new URL(req.url, `http://127.0.0.1:${PORT}`);
+  const code = url.searchParams.get('code');
+  const error = url.searchParams.get('error');
+
+  if (error || !code) {
+    res.writeHead(400, { 'Content-Type': 'text/html' });
+    res.end('<h1>Authorization denied.</h1>');
+    console.error('Authorization denied:', error);
+    process.exit(1);
+  }
+
+  const tokenRes = await fetch('https://accounts.spotify.com/api/token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`,
+    },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: REDIRECT_URI,
+    }),
+  });
+
+  const data = await tokenRes.json();
+
+  if (!data.refresh_token) {
+    res.writeHead(500, { 'Content-Type': 'text/html' });
+    res.end('<h1>Error getting refresh token.</h1>');
+    console.error('Token response:', data);
+    process.exit(1);
+  }
+
+  res.writeHead(200, { 'Content-Type': 'text/html' });
+  res.end('<h1>Done! You can close this tab.</h1><p>Check your terminal for the refresh token.</p>');
+
+  console.log('──────────────────────────────────────');
+  console.log('SPOTIFY_REFRESH_TOKEN:');
+  console.log(data.refresh_token);
+  console.log('──────────────────────────────────────');
+  console.log('\nAdd these to your .env:');
+  console.log(`SPOTIFY_CLIENT_ID=${clientId}`);
+  console.log(`SPOTIFY_CLIENT_SECRET=${clientSecret}`);
+  console.log(`SPOTIFY_REFRESH_TOKEN=${data.refresh_token}`);
+  console.log('');
+
+  server.close(() => process.exit(0));
+});
+
+server.listen(PORT, '127.0.0.1', () => {
+  console.log(`Listening on http://127.0.0.1:${PORT} ...\n`);
+});

--- a/src/components/main/Footer.vue
+++ b/src/components/main/Footer.vue
@@ -4,9 +4,7 @@
       <!-- Now Playing -->
       <div v-if="nowPlaying?.isPlaying" class="flex items-center justify-center gap-2 pb-1.5 mb-1.5 border-b border-nw-text-faint/30">
         <span class="font-stamp uppercase tracking-[0.14em] text-[10px] text-nw-text-faint shrink-0">NOW PLAYING</span>
-        <div class="now-playing-bars">
-          <span /><span /><span />
-        </div>
+        <NowPlayingBars />
         <a
           :href="nowPlaying.spotifyUrl"
           target="_blank"
@@ -138,27 +136,3 @@ if (import.meta.client) {
   });
 }
 </script>
-
-<style scoped>
-.now-playing-bars {
-  display: flex;
-  align-items: flex-end;
-  gap: 1px;
-  height: 10px;
-}
-.now-playing-bars span {
-  display: block;
-  width: 2px;
-  background: currentColor;
-  animation: eq-bar 0.8s ease-in-out infinite alternate;
-}
-.now-playing-bars span:nth-child(1) { height: 4px; animation-delay: 0s; }
-.now-playing-bars span:nth-child(2) { height: 7px; animation-delay: 0.2s; }
-.now-playing-bars span:nth-child(3) { height: 5px; animation-delay: 0.4s; }
-.now-playing-bars { @apply text-nw-green; }
-
-@keyframes eq-bar {
-  0% { height: 3px; }
-  100% { height: 10px; }
-}
-</style>

--- a/src/components/main/Footer.vue
+++ b/src/components/main/Footer.vue
@@ -1,6 +1,22 @@
 <template>
-  <footer class="bg-void border-t border-nw-text-faint">
+  <footer class="sticky bottom-0 z-40 bg-void border-t border-nw-text-faint">
     <div class="container mx-auto px-4 py-2">
+      <!-- Now Playing -->
+      <div v-if="nowPlaying?.isPlaying" class="flex items-center justify-center gap-2 pb-1.5 mb-1.5 border-b border-nw-text-faint/30">
+        <span class="font-stamp uppercase tracking-[0.14em] text-[10px] text-nw-text-faint shrink-0">NOW PLAYING</span>
+        <div class="now-playing-bars">
+          <span /><span /><span />
+        </div>
+        <a
+          :href="nowPlaying.spotifyUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="font-mono text-[10px] normal-case tracking-normal text-nw-green hover:text-nw-primary-hot transition-colors truncate max-w-[280px] md:max-w-[400px]"
+        >
+          {{ nowPlaying.track }} <span class="text-nw-text-dim">— {{ nowPlaying.artist }}</span>
+        </a>
+      </div>
+
       <div class="flex flex-col md:flex-row justify-between items-center gap-2 font-stamp uppercase tracking-[0.1em] text-[10px]">
         <!-- Left: System status + version -->
         <div class="flex items-center gap-2 text-nw-text-dim">
@@ -54,6 +70,8 @@
 <script lang="ts" setup>
 import { ref, computed, onMounted, onUnmounted } from 'vue';
 
+const { nowPlaying } = useNowPlaying();
+
 const currentYear = new Date().getFullYear();
 
 // Live clock for UTC-6 (El Salvador)
@@ -62,7 +80,6 @@ let clockInterval: ReturnType<typeof setInterval> | null = null;
 
 function updateClock() {
   const now = new Date();
-  // UTC-6 offset (El Salvador, no DST)
   const sv = new Date(now.getTime() + (now.getTimezoneOffset() - 360) * 60 * 1000);
   const hh = String(sv.getHours()).padStart(2, '0');
   const mm = String(sv.getMinutes()).padStart(2, '0');
@@ -121,3 +138,27 @@ if (import.meta.client) {
   });
 }
 </script>
+
+<style scoped>
+.now-playing-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 1px;
+  height: 10px;
+}
+.now-playing-bars span {
+  display: block;
+  width: 2px;
+  background: currentColor;
+  animation: eq-bar 0.8s ease-in-out infinite alternate;
+}
+.now-playing-bars span:nth-child(1) { height: 4px; animation-delay: 0s; }
+.now-playing-bars span:nth-child(2) { height: 7px; animation-delay: 0.2s; }
+.now-playing-bars span:nth-child(3) { height: 5px; animation-delay: 0.4s; }
+.now-playing-bars { @apply text-nw-green; }
+
+@keyframes eq-bar {
+  0% { height: 3px; }
+  100% { height: 10px; }
+}
+</style>

--- a/src/components/ui/NowPlayingBars.vue
+++ b/src/components/ui/NowPlayingBars.vue
@@ -1,0 +1,27 @@
+<template>
+  <span class="now-playing-bars"><span /><span /><span /></span>
+</template>
+
+<style scoped>
+.now-playing-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 1px;
+  height: 10px;
+  @apply text-nw-green;
+}
+.now-playing-bars span {
+  display: block;
+  width: 2px;
+  background: currentColor;
+  animation: eq-bar 0.8s ease-in-out infinite alternate;
+}
+.now-playing-bars span:nth-child(1) { height: 4px; animation-delay: 0s; }
+.now-playing-bars span:nth-child(2) { height: 7px; animation-delay: 0.2s; }
+.now-playing-bars span:nth-child(3) { height: 5px; animation-delay: 0.4s; }
+
+@keyframes eq-bar {
+  0% { height: 3px; }
+  100% { height: 10px; }
+}
+</style>

--- a/src/composables/useNowPlaying.ts
+++ b/src/composables/useNowPlaying.ts
@@ -1,0 +1,37 @@
+interface NowPlayingData {
+  isPlaying: boolean
+  track?: string
+  artist?: string
+  album?: string
+  albumArt?: string
+  spotifyUrl?: string
+  progressMs?: number
+  durationMs?: number
+}
+
+export function useNowPlaying() {
+  const data = useState<NowPlayingData>('now-playing', () => ({ isPlaying: false }))
+
+  async function fetchNowPlaying() {
+    try {
+      data.value = await $fetch<NowPlayingData>('/api/spotify/now-playing')
+    } catch {
+      data.value = { isPlaying: false }
+    }
+  }
+
+  if (import.meta.client) {
+    let interval: ReturnType<typeof setInterval> | null = null
+
+    onMounted(() => {
+      fetchNowPlaying()
+      interval = setInterval(fetchNowPlaying, 5_000)
+    })
+
+    onUnmounted(() => {
+      if (interval) clearInterval(interval)
+    })
+  }
+
+  return { nowPlaying: data }
+}

--- a/src/composables/useNowPlaying.ts
+++ b/src/composables/useNowPlaying.ts
@@ -1,3 +1,5 @@
+import { onMounted, onUnmounted } from 'vue'
+
 interface NowPlayingData {
   isPlaying: boolean
   track?: string
@@ -11,25 +13,41 @@ interface NowPlayingData {
 
 export function useNowPlaying() {
   const data = useState<NowPlayingData>('now-playing', () => ({ isPlaying: false }))
+  let lastFetchTime = 0
 
   async function fetchNowPlaying() {
     try {
-      data.value = await $fetch<NowPlayingData>('/api/spotify/now-playing')
+      const result = await $fetch<NowPlayingData>('/api/spotify/now-playing')
+      data.value = result
+      lastFetchTime = Date.now()
     } catch {
       data.value = { isPlaying: false }
     }
   }
 
   if (import.meta.client) {
-    let interval: ReturnType<typeof setInterval> | null = null
+    let fetchInterval: ReturnType<typeof setInterval> | null = null
+    let progressInterval: ReturnType<typeof setInterval> | null = null
 
     onMounted(() => {
       fetchNowPlaying()
-      interval = setInterval(fetchNowPlaying, 5_000)
+      fetchInterval = setInterval(fetchNowPlaying, 5_000)
+
+      // Interpolate progress smoothly between 5s polls
+      progressInterval = setInterval(() => {
+        if (data.value.isPlaying && data.value.progressMs !== undefined && data.value.durationMs !== undefined) {
+          const elapsed = Date.now() - lastFetchTime
+          // Add elapsed time to the base progress we got from the API, capping at duration
+          data.value.progressMs = Math.min(data.value.progressMs + 1000, data.value.durationMs)
+          // Update lastFetchTime so we only add 1s next tick
+          lastFetchTime = Date.now()
+        }
+      }, 1000)
     })
 
     onUnmounted(() => {
-      if (interval) clearInterval(interval)
+      if (fetchInterval) clearInterval(fetchInterval)
+      if (progressInterval) clearInterval(progressInterval)
     })
   }
 

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col min-h-screen bg-void-warm text-nw-text font-sys">
     <Header />
-    <main class="container mx-auto p-4 flex-grow">
+    <main class="container mx-auto p-4 pb-20 flex-grow">
       <slot />
     </main>
     <Footer />

--- a/src/pages/now.vue
+++ b/src/pages/now.vue
@@ -18,6 +18,53 @@
       </div>
     </div>
 
+    <!-- NOW PLAYING -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>NOW PLAYING · SPOTIFY</span>
+        <span v-if="nowPlaying?.isPlaying" class="now-playing-bars"><span /><span /><span /></span>
+      </div>
+      <div class="panel-body p-4">
+        <div v-if="nowPlaying?.isPlaying" class="flex items-center gap-4">
+          <img
+            v-if="nowPlaying.albumArt"
+            :src="nowPlaying.albumArt"
+            :alt="nowPlaying.album"
+            class="w-14 h-14 rounded-sm border border-nw-text-faint/20 shrink-0"
+          />
+          <div class="flex-1 min-w-0 space-y-1">
+            <a
+              :href="nowPlaying.spotifyUrl"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="block text-nw-text font-mono text-sm hover:text-nw-primary-hot transition-colors truncate"
+            >
+              {{ nowPlaying.track }}
+            </a>
+            <div class="text-nw-text-dim text-xs font-mono truncate">{{ nowPlaying.artist }} · {{ nowPlaying.album }}</div>
+            <div class="flex items-center gap-2">
+              <span class="text-nw-text-faint text-[10px] font-mono w-8 text-right shrink-0">{{ formatMs(nowPlaying.progressMs) }}</span>
+              <div class="flex-1 h-[3px] bg-nw-text-faint/20 rounded-full overflow-hidden">
+                <div class="h-full bg-nw-green rounded-full transition-all duration-1000" :style="{ width: progressPercent + '%' }" />
+              </div>
+              <span class="text-nw-text-faint text-[10px] font-mono w-8 shrink-0">{{ formatMs(nowPlaying.durationMs) }}</span>
+            </div>
+          </div>
+          <a
+            :href="nowPlaying.spotifyUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="font-stamp uppercase tracking-[0.14em] text-[10px] text-nw-green hover:text-nw-primary-hot transition-colors shrink-0 hidden sm:block"
+          >
+            OPEN IN SPOTIFY →
+          </a>
+        </div>
+        <div v-else class="text-nw-text-dim text-xs font-mono py-1">
+          Nothing playing right now.
+        </div>
+      </div>
+    </div>
+
     <!-- AT WORK -->
     <div class="panel">
       <div class="panel-header">
@@ -156,7 +203,46 @@
 <script lang="ts" setup>
 const lastUpdated = '2026-05-01';
 
+const { nowPlaying } = useNowPlaying();
+
+function formatMs(ms?: number): string {
+  if (!ms) return '0:00';
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}
+
+const progressPercent = computed(() => {
+  if (!nowPlaying.value?.progressMs || !nowPlaying.value?.durationMs) return 0;
+  return Math.min(100, (nowPlaying.value.progressMs / nowPlaying.value.durationMs) * 100);
+});
+
 usePageTitle('Now', {
   description: 'What Carlos Cativo is working on right now — at Blue Medical Guatemala, on side projects, on his self-hosted infra, and what kind of next role he\'s looking for.',
 });
 </script>
+
+<style scoped>
+.now-playing-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 1px;
+  height: 10px;
+}
+.now-playing-bars span {
+  display: block;
+  width: 2px;
+  background: currentColor;
+  animation: eq-bar 0.8s ease-in-out infinite alternate;
+}
+.now-playing-bars span:nth-child(1) { height: 4px; animation-delay: 0s; }
+.now-playing-bars span:nth-child(2) { height: 7px; animation-delay: 0.2s; }
+.now-playing-bars span:nth-child(3) { height: 5px; animation-delay: 0.4s; }
+.now-playing-bars { @apply text-nw-green; }
+
+@keyframes eq-bar {
+  0% { height: 3px; }
+  100% { height: 10px; }
+}
+</style>

--- a/src/pages/now.vue
+++ b/src/pages/now.vue
@@ -22,7 +22,7 @@
     <div class="panel">
       <div class="panel-header">
         <span>NOW PLAYING · SPOTIFY</span>
-        <span v-if="nowPlaying?.isPlaying" class="now-playing-bars"><span /><span /><span /></span>
+        <NowPlayingBars v-if="nowPlaying?.isPlaying" />
       </div>
       <div class="panel-body p-4">
         <div v-if="nowPlaying?.isPlaying" class="flex items-center gap-4">
@@ -222,27 +222,3 @@ usePageTitle('Now', {
   description: 'What Carlos Cativo is working on right now — at Blue Medical Guatemala, on side projects, on his self-hosted infra, and what kind of next role he\'s looking for.',
 });
 </script>
-
-<style scoped>
-.now-playing-bars {
-  display: flex;
-  align-items: flex-end;
-  gap: 1px;
-  height: 10px;
-}
-.now-playing-bars span {
-  display: block;
-  width: 2px;
-  background: currentColor;
-  animation: eq-bar 0.8s ease-in-out infinite alternate;
-}
-.now-playing-bars span:nth-child(1) { height: 4px; animation-delay: 0s; }
-.now-playing-bars span:nth-child(2) { height: 7px; animation-delay: 0.2s; }
-.now-playing-bars span:nth-child(3) { height: 5px; animation-delay: 0.4s; }
-.now-playing-bars { @apply text-nw-green; }
-
-@keyframes eq-bar {
-  0% { height: 3px; }
-  100% { height: 10px; }
-}
-</style>

--- a/src/server/api/spotify/now-playing.get.ts
+++ b/src/server/api/spotify/now-playing.get.ts
@@ -1,0 +1,6 @@
+import { fetchNowPlaying } from '~/server/utils/spotify'
+
+export default defineEventHandler(async (event) => {
+  const { spotifyClientId, spotifyClientSecret, spotifyRefreshToken } = useRuntimeConfig(event)
+  return fetchNowPlaying(spotifyClientId, spotifyClientSecret, spotifyRefreshToken)
+})

--- a/src/server/utils/spotify.ts
+++ b/src/server/utils/spotify.ts
@@ -15,6 +15,33 @@ interface SpotifyTokenResponse {
   expires_in: number
 }
 
+interface SpotifyArtist {
+  name: string
+}
+
+interface SpotifyImage {
+  url: string
+  height: number
+  width: number
+}
+
+interface SpotifyCurrentlyPlayingResponse {
+  is_playing: boolean
+  progress_ms: number
+  item: {
+    name: string
+    duration_ms: number
+    artists: SpotifyArtist[]
+    album: {
+      name: string
+      images: SpotifyImage[]
+    }
+    external_urls: {
+      spotify: string
+    }
+  } | null
+}
+
 let cachedToken: { token: string; expiresAt: number } | null = null
 let cachedState: { data: SpotifyNowPlaying; fetchedAt: number } | null = null
 let rateLimitedUntil = 0
@@ -62,10 +89,15 @@ export async function fetchNowPlaying(clientId: string, clientSecret: string, re
   try {
     const token = await getAccessToken(clientId, clientSecret, refreshToken)
 
-    const res = await $fetch<any>('https://api.spotify.com/v1/me/player/currently-playing', {
+    const res = await $fetch<SpotifyCurrentlyPlayingResponse>('https://api.spotify.com/v1/me/player/currently-playing', {
       headers: { Authorization: `Bearer ${token}` },
       timeout: 5000,
-    }).catch(() => null)
+    }).catch((err) => {
+      if (err?.response?.status !== 429) {
+        console.warn('[Spotify API] Error fetching now playing:', err.message || err);
+      }
+      throw err;
+    })
 
     const data: SpotifyNowPlaying = (!res || !res.item)
       ? { isPlaying: false }

--- a/src/server/utils/spotify.ts
+++ b/src/server/utils/spotify.ts
@@ -46,6 +46,13 @@ let cachedToken: { token: string; expiresAt: number } | null = null
 let cachedState: { data: SpotifyNowPlaying; fetchedAt: number } | null = null
 let rateLimitedUntil = 0
 
+// For testing purposes
+export function _clearSpotifyCache() {
+  cachedToken = null
+  cachedState = null
+  rateLimitedUntil = 0
+}
+
 const POLL_INTERVAL = 5_000
 
 async function getAccessToken(clientId: string, clientSecret: string, refreshToken: string): Promise<string> {

--- a/src/server/utils/spotify.ts
+++ b/src/server/utils/spotify.ts
@@ -1,0 +1,92 @@
+export interface SpotifyNowPlaying {
+  isPlaying: boolean
+  track?: string
+  artist?: string
+  album?: string
+  albumArt?: string
+  spotifyUrl?: string
+  progressMs?: number
+  durationMs?: number
+}
+
+interface SpotifyTokenResponse {
+  access_token: string
+  token_type: string
+  expires_in: number
+}
+
+let cachedToken: { token: string; expiresAt: number } | null = null
+let cachedState: { data: SpotifyNowPlaying; fetchedAt: number } | null = null
+let rateLimitedUntil = 0
+
+const POLL_INTERVAL = 5_000
+
+async function getAccessToken(clientId: string, clientSecret: string, refreshToken: string): Promise<string> {
+  if (cachedToken && Date.now() < cachedToken.expiresAt) {
+    return cachedToken.token
+  }
+
+  const res = await $fetch<SpotifyTokenResponse>('https://accounts.spotify.com/api/token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`,
+    },
+    body: new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+    }).toString(),
+  })
+
+  cachedToken = {
+    token: res.access_token,
+    expiresAt: Date.now() + (res.expires_in - 60) * 1000,
+  }
+
+  return res.access_token
+}
+
+export async function fetchNowPlaying(clientId: string, clientSecret: string, refreshToken: string): Promise<SpotifyNowPlaying> {
+  if (!clientId || !clientSecret || !refreshToken) {
+    return { isPlaying: false }
+  }
+
+  if (cachedState && Date.now() - cachedState.fetchedAt < POLL_INTERVAL) {
+    return cachedState.data
+  }
+
+  if (Date.now() < rateLimitedUntil) {
+    return cachedState?.data ?? { isPlaying: false }
+  }
+
+  try {
+    const token = await getAccessToken(clientId, clientSecret, refreshToken)
+
+    const res = await $fetch<any>('https://api.spotify.com/v1/me/player/currently-playing', {
+      headers: { Authorization: `Bearer ${token}` },
+      timeout: 5000,
+    }).catch(() => null)
+
+    const data: SpotifyNowPlaying = (!res || !res.item)
+      ? { isPlaying: false }
+      : {
+          isPlaying: res.is_playing ?? false,
+          track: res.item.name,
+          artist: res.item.artists?.map((a: any) => a.name).join(', '),
+          album: res.item.album?.name,
+          albumArt: res.item.album?.images?.[0]?.url,
+          spotifyUrl: res.item.external_urls?.spotify,
+          progressMs: res.progress_ms ?? 0,
+          durationMs: res.item.duration_ms ?? 0,
+        }
+
+    cachedState = { data, fetchedAt: Date.now() }
+    return data
+  } catch (err: any) {
+    if (err?.response?.status === 429) {
+      const retryAfter = parseInt(err.response.headers?.get?.('retry-after') || '30', 10)
+      rateLimitedUntil = Date.now() + retryAfter * 1000
+    }
+    return cachedState?.data ?? { isPlaying: false }
+  }
+}

--- a/tests/server/utils/spotify.test.ts
+++ b/tests/server/utils/spotify.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { fetchNowPlaying, _clearSpotifyCache } from '../../../src/server/utils/spotify'
+
+// Mock the global $fetch
+const viFetch = vi.fn()
+global.$fetch = viFetch as any
+
+describe('fetchNowPlaying', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.useFakeTimers()
+    _clearSpotifyCache()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should return isPlaying: false if credentials are missing', async () => {
+    const res = await fetchNowPlaying('', '', '')
+    expect(res).toEqual({ isPlaying: false })
+  })
+
+  it('should get a token and fetch currently playing track', async () => {
+    // Mock token response
+    viFetch.mockResolvedValueOnce({
+      access_token: 'mock-token',
+      expires_in: 3600,
+    })
+
+    // Mock Spotify API response
+    viFetch.mockResolvedValueOnce({
+      is_playing: true,
+      progress_ms: 1000,
+      item: {
+        name: 'Test Track',
+        duration_ms: 3000,
+        artists: [{ name: 'Test Artist' }],
+        album: {
+          name: 'Test Album',
+          images: [{ url: 'test-art.jpg', height: 300, width: 300 }],
+        },
+        external_urls: {
+          spotify: 'https://spotify.com/track',
+        },
+      },
+    })
+
+    const res = await fetchNowPlaying('client', 'secret', 'refresh')
+
+    expect(res).toEqual({
+      isPlaying: true,
+      track: 'Test Track',
+      artist: 'Test Artist',
+      album: 'Test Album',
+      albumArt: 'test-art.jpg',
+      spotifyUrl: 'https://spotify.com/track',
+      progressMs: 1000,
+      durationMs: 3000,
+    })
+
+    // Verify token request
+    expect(viFetch).toHaveBeenNthCalledWith(1, 'https://accounts.spotify.com/api/token', expect.any(Object))
+    // Verify API request
+    expect(viFetch).toHaveBeenNthCalledWith(2, 'https://api.spotify.com/v1/me/player/currently-playing', {
+      headers: { Authorization: 'Bearer mock-token' },
+      timeout: 5000,
+    })
+  })
+
+  it('should return isPlaying: false if nothing is playing', async () => {
+    // Return cached token to skip token request
+    // Set time to be within cached token validity
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+
+    // Token call
+    viFetch.mockResolvedValueOnce({
+      access_token: 'mock-token-2',
+      expires_in: 3600,
+    })
+
+    // Nothing playing API response
+    viFetch.mockResolvedValueOnce(null)
+
+    const res = await fetchNowPlaying('client', 'secret', 'refresh')
+    expect(res).toEqual({ isPlaying: false })
+  })
+
+  it('should return cached data if called within POLL_INTERVAL', async () => {
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+
+    // Initial call
+    viFetch.mockResolvedValueOnce({ access_token: 'token', expires_in: 3600 })
+    viFetch.mockResolvedValueOnce({
+      is_playing: true,
+      item: { name: 'Track A', artists: [] },
+    })
+
+    await fetchNowPlaying('c', 's', 'r')
+
+    // Advance time by 2 seconds (less than POLL_INTERVAL of 5s)
+    vi.advanceTimersByTime(2000)
+
+    const res2 = await fetchNowPlaying('c', 's', 'r')
+
+    // Should return cached track A, and $fetch should only have been called twice total
+    expect(res2.track).toBe('Track A')
+    expect(viFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('should respect rate limits via Retry-After', async () => {
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    viFetch.mockResolvedValueOnce({ access_token: 'token', expires_in: 3600 })
+
+    // Force a 429 error
+    const error429 = new Error('Rate Limited') as any
+    error429.response = {
+      status: 429,
+      headers: {
+        get: () => '10' // 10 seconds retry-after
+      }
+    }
+    viFetch.mockRejectedValueOnce(error429)
+
+    // Should gracefully fail to isPlaying: false
+    const res1 = await fetchNowPlaying('c', 's', 'r')
+    expect(res1.isPlaying).toBe(false)
+
+    // Clear mock counts
+    viFetch.mockClear()
+
+    // Advance time by 5 seconds (POLL_INTERVAL has passed, but still rate limited)
+    vi.advanceTimersByTime(5000)
+
+    const res2 = await fetchNowPlaying('c', 's', 'r')
+    expect(res2.isPlaying).toBe(false)
+    // Should NOT have made an API call because it's rate limited
+    expect(viFetch).not.toHaveBeenCalled()
+
+    // Advance time past the 10s rate limit
+    vi.advanceTimersByTime(6000)
+
+    // We don't need a token mock because cachedToken is still valid (expires in 3600s)
+    viFetch.mockResolvedValueOnce({
+      is_playing: true,
+      item: { name: 'Track B', artists: [] }
+    })
+
+    const res3 = await fetchNowPlaying('c', 's', 'r')
+    expect(res3.track).toBe('Track B')
+  })
+})


### PR DESCRIPTION
## Summary
- **Server API** (`/api/spotify/now-playing`) — fetches currently playing track with 5s server-side cache and Retry-After backoff on 429s
- **Footer widget** — sticky, compact "NOW PLAYING" bar with animated equalizer, visible on all pages
- **`/now` page panel** — detailed view with album art, progress bar, timestamps, and "OPEN IN SPOTIFY" link
- **Shared composable** (`useNowPlaying`) — polls every 5s, shared state via `useState`
- **OAuth helper** (`scripts/spotify-token.mjs`) — one-time script to generate Spotify refresh token

## Config required
Add to `.env` and server environment:
```
SPOTIFY_CLIENT_ID=...
SPOTIFY_CLIENT_SECRET=...
SPOTIFY_REFRESH_TOKEN=...
```

## Test plan
- [ ] Play a song on Spotify, verify it appears in footer and /now page within ~10s
- [ ] Skip a track, verify update within ~10s
- [ ] Pause playback, verify "Nothing playing" state
- [ ] Check mobile responsive layout (footer truncation, /now page stacking)