### PR TITLE
fix(deploy): wire prod runtime env and cap container memory

### DIFF
--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -4,14 +4,18 @@ services:
   app:
     image: ${DOCKER_USERNAME:-cativo23}/portfolio:latest
     restart: unless-stopped
+    mem_limit: 1g
     environment:
       NODE_ENV: production
-      NODE_OPTIONS: --max-old-space-size=4096
+      NODE_OPTIONS: --max-old-space-size=768
       PORT: 3000
+      NUXT_API_BASE_URL: ${NUXT_API_BASE_URL:?NUXT_API_BASE_URL is required}
+      NUXT_API_BASE_PATH: ${NUXT_API_BASE_PATH:?NUXT_API_BASE_PATH is required}
+      NUXT_API_TOKEN: ${NUXT_API_TOKEN:?NUXT_API_TOKEN is required}
       NUXT_GITHUB_TOKEN: ${POW_GH_TOKEN:?POW_GH_TOKEN is required}
-      SPOTIFY_CLIENT_ID: ${SPOTIFY_CLIENT_ID:-}
-      SPOTIFY_CLIENT_SECRET: ${SPOTIFY_CLIENT_SECRET:-}
-      SPOTIFY_REFRESH_TOKEN: ${SPOTIFY_REFRESH_TOKEN:-}
+      NUXT_SPOTIFY_CLIENT_ID: ${NUXT_SPOTIFY_CLIENT_ID:-}
+      NUXT_SPOTIFY_CLIENT_SECRET: ${NUXT_SPOTIFY_CLIENT_SECRET:-}
+      NUXT_SPOTIFY_REFRESH_TOKEN: ${NUXT_SPOTIFY_REFRESH_TOKEN:-}
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://localhost:3000').then(r => { if (!r.ok) process.exit(1) }).catch(() => process.exit(1))"]
       interval: 30s


### PR DESCRIPTION
## Summary

- Wire `NUXT_API_BASE_URL` / `NUXT_API_BASE_PATH` / `NUXT_API_TOKEN` into `compose.prod.yml` with `:?required` guards. v1.10.7 (commit 6f06d6c) removed the hardcoded `process.env.* || 'http://api:3000'` fallbacks from `runtimeConfig` in `nuxt.config.ts`, but the prod compose was never updated to pass those env vars. Result: `config.apiBaseUrl=''`, so `src/server/api/projects.get.ts` and `profile.get.ts` resolve `${config.apiBaseUrl}${config.apiBasePath}/projects` → `/projects`, loop back into the same Nitro server, allocate ~30 MB/s and OOM the container at the V8 heap cap (~130 s after `Listening on`).
- Rename `SPOTIFY_*` → `NUXT_SPOTIFY_*`. Nuxt 3 only auto-overrides `runtimeConfig.spotifyClientId` from the `NUXT_`-prefixed env var; the previous naming meant the container got empty strings and `fetchNowPlaying` short-circuited silently.
- Add `mem_limit: 1g` and drop `--max-old-space-size` from 4096 to 768. A future regression hits a hard cap and dies cleanly instead of dragging the host down (the previous 4 GiB limit was 80× normal usage — fine on a 7.6 GiB host today, dangerous tomorrow).

## Repro (before this change)

| Image | Env | Result |
|---|---|---|
| `v1.10.3` | `NUXT_GITHUB_TOKEN=dummy` | 48 MiB, HTML in <1 s |
| `v1.10.4` | idem | 30 MiB, HTML in <1 s |
| `v1.10.7` | idem | hangs, 927 MiB, 110 % CPU, OOMs at ~130 s |
| `v1.10.7` | + `NUXT_API_BASE_URL/PATH/TOKEN` | 47 MiB, HTML in <1 s |

Validated live on polaris2 with the fixed compose:

- `https://cativo.dev/` → HTTP 200, 237 ms
- `https://cativo.dev/now` → HTTP 200, 100 ms
- `https://cativo.dev/api/spotify/now-playing` → HTTP 200 with real track data
- Container: `healthy`, ~28 MiB, 0 % CPU, 0 restarts

## Out of scope (follow-ups)

- `compose.yml` (dev) has the same `SPOTIFY_*` naming bug — separate PR.
- `.env` on the server has duplicated `NUXT_SPOTIFY_*` entries (empty values shadowed by real ones); harmless but worth cleaning.
- `deploy.yml` doesn't pass these new vars via the GH Actions `envs:` block — the deploy still works because they live in the server's `.env`, but worth tightening later.

## Test plan

- [x] `docker compose -f compose.prod.yml config` resolves all required vars from server `.env`
- [x] `docker compose up -d --force-recreate` boots clean on polaris2
- [x] Public `https://cativo.dev/` returns 200
- [x] `/api/spotify/now-playing` returns real Spotify payload
- [x] Container reports `healthy` after start_period