### PR TITLE
feat(a11y): focus trap mobile menu and enable image optimization

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -80,6 +80,6 @@ export default defineNuxtConfig({
   modules,
   builder: "vite",
   image: {
-    provider: 'none',
+    provider: 'ipx',
   },
 })

--- a/src/components/main/Header.vue
+++ b/src/components/main/Header.vue
@@ -54,6 +54,7 @@
     >
       <div
         v-if="isMenuOpen"
+        ref="drawerRef"
         class="fixed inset-0 bg-void/95 z-20 flex flex-col items-center justify-center md:hidden"
         role="dialog"
         aria-modal="true"
@@ -90,8 +91,11 @@
 <script lang="ts" setup>
 import { ref } from 'vue';
 import { useRoute } from 'vue-router';
+import { useFocusTrap } from '~/composables/useFocusTrap';
 
 const isMenuOpen = ref(false);
+const drawerRef = ref<HTMLElement | null>(null);
+useFocusTrap(drawerRef, isMenuOpen, () => (isMenuOpen.value = false));
 
 const navItems = ref([
   { label: 'Home', path: '/' },

--- a/src/composables/useFocusTrap.ts
+++ b/src/composables/useFocusTrap.ts
@@ -1,0 +1,108 @@
+import { nextTick, onScopeDispose, watch, type Ref } from 'vue'
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+  'input:not([disabled])',
+  'textarea:not([disabled])',
+  'select:not([disabled])',
+].join(', ')
+
+function getFocusable(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+}
+
+export function useFocusTrap(
+  containerRef: Ref<HTMLElement | null>,
+  isActive: Ref<boolean>,
+  onEscape?: () => void,
+): void {
+  // SSR-safe: bail out on the server.
+  if (typeof document === 'undefined') return
+
+  let previouslyFocused: HTMLElement | null = null
+  let keydownHandler: ((e: KeyboardEvent) => void) | null = null
+
+  function detach() {
+    if (keydownHandler) {
+      document.removeEventListener('keydown', keydownHandler)
+      keydownHandler = null
+    }
+  }
+
+  function activate() {
+    previouslyFocused = (document.activeElement as HTMLElement | null) ?? null
+
+    nextTick(() => {
+      const container = containerRef.value
+      if (!container) return
+      const focusable = getFocusable(container)
+      if (focusable.length > 0) {
+        focusable[0]?.focus()
+      } else {
+        // Fall back to focusing the container itself so the trap holds.
+        container.focus?.()
+      }
+    })
+
+    keydownHandler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onEscape?.()
+        return
+      }
+      if (e.key !== 'Tab') return
+
+      const container = containerRef.value
+      if (!container) return
+      const focusable = getFocusable(container)
+      if (focusable.length === 0) {
+        e.preventDefault()
+        return
+      }
+      const first = focusable[0]!
+      const last = focusable[focusable.length - 1]!
+      const active = document.activeElement as HTMLElement | null
+
+      if (e.shiftKey) {
+        if (active === first || !container.contains(active)) {
+          e.preventDefault()
+          last.focus()
+        }
+      } else {
+        if (active === last || !container.contains(active)) {
+          e.preventDefault()
+          first.focus()
+        }
+      }
+    }
+
+    document.addEventListener('keydown', keydownHandler)
+  }
+
+  function deactivate() {
+    detach()
+    const target = previouslyFocused
+    previouslyFocused = null
+    if (target && document.contains(target)) {
+      target.focus()
+    }
+  }
+
+  watch(
+    isActive,
+    (active, _prev) => {
+      if (active) {
+        activate()
+      } else {
+        deactivate()
+      }
+    },
+    { immediate: true },
+  )
+
+  onScopeDispose(() => {
+    detach()
+    previouslyFocused = null
+  })
+}

--- a/src/pages/projects/[id].vue
+++ b/src/pages/projects/[id].vue
@@ -61,6 +61,7 @@
           :alt="`${project.title} screenshot`"
           class="w-full h-full object-cover"
           sizes="sm:100vw md:1200px lg:1200px"
+          loading="lazy"
           placeholder
           @error="() => (imageError = true)"
         />

--- a/tests/composables/useFocusTrap.test.ts
+++ b/tests/composables/useFocusTrap.test.ts
@@ -164,4 +164,27 @@ describe('useFocusTrap', () => {
 
     wrapper.unmount()
   })
+
+  it('detaches the keydown listener when unmounted while active', async () => {
+    const containerRef = ref<HTMLElement | null>(null)
+    const isActive = ref(false)
+    const onEscape = vi.fn()
+    const wrapper = mount(makeHost(containerRef, isActive, onEscape), {
+      attachTo: document.body,
+    })
+
+    isActive.value = true
+    await nextTick()
+    await nextTick()
+
+    // Sanity check: listener is wired up.
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(onEscape).toHaveBeenCalledTimes(1)
+
+    wrapper.unmount()
+
+    // After unmount, no further keydown should reach the trap.
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(onEscape).toHaveBeenCalledTimes(1)
+  })
 })

--- a/tests/composables/useFocusTrap.test.ts
+++ b/tests/composables/useFocusTrap.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { defineComponent, h, nextTick, ref, type Ref } from 'vue'
+import { mount } from '@vue/test-utils'
+
+const { useFocusTrap } = await import('~/composables/useFocusTrap')
+
+function makeHost(
+  containerRef: Ref<HTMLElement | null>,
+  isActive: Ref<boolean>,
+  onEscape?: () => void,
+) {
+  return defineComponent({
+    setup() {
+      useFocusTrap(containerRef, isActive, onEscape)
+      return () =>
+        h(
+          'div',
+          {
+            ref: (el) => {
+              containerRef.value = el as HTMLElement | null
+            },
+            tabindex: -1,
+          },
+          [
+            h('button', { id: 'first' }, 'first'),
+            h('a', { id: 'middle', href: '#' }, 'middle'),
+            h('button', { id: 'last' }, 'last'),
+          ],
+        )
+    },
+  })
+}
+
+describe('useFocusTrap', () => {
+  let externalButton: HTMLButtonElement
+
+  beforeEach(() => {
+    // External focusable element to simulate the trigger (so we can verify restoration).
+    externalButton = document.createElement('button')
+    externalButton.id = 'trigger'
+    document.body.appendChild(externalButton)
+    externalButton.focus()
+  })
+
+  afterEach(() => {
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild)
+    }
+  })
+
+  it('does not attach keydown listener while inactive', () => {
+    const addSpy = vi.spyOn(document, 'addEventListener')
+    const containerRef = ref<HTMLElement | null>(null)
+    const isActive = ref(false)
+    const onEscape = vi.fn()
+
+    const wrapper = mount(makeHost(containerRef, isActive, onEscape), {
+      attachTo: document.body,
+    })
+
+    const keydownCalls = addSpy.mock.calls.filter(([type]) => type === 'keydown')
+    expect(keydownCalls).toHaveLength(0)
+
+    // Dispatching escape should be a no-op.
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(onEscape).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+    addSpy.mockRestore()
+  })
+
+  it('focuses the first focusable element when activated', async () => {
+    const containerRef = ref<HTMLElement | null>(null)
+    const isActive = ref(false)
+    const wrapper = mount(makeHost(containerRef, isActive), { attachTo: document.body })
+
+    isActive.value = true
+    await nextTick()
+    await nextTick()
+
+    const first = wrapper.get('#first').element as HTMLElement
+    expect(document.activeElement).toBe(first)
+
+    wrapper.unmount()
+  })
+
+  it('invokes the onEscape callback when Escape is pressed', async () => {
+    const containerRef = ref<HTMLElement | null>(null)
+    const isActive = ref(false)
+    const onEscape = vi.fn()
+    const wrapper = mount(makeHost(containerRef, isActive, onEscape), {
+      attachTo: document.body,
+    })
+
+    isActive.value = true
+    await nextTick()
+    await nextTick()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(onEscape).toHaveBeenCalledTimes(1)
+
+    wrapper.unmount()
+  })
+
+  it('restores focus to the previously focused element on deactivation', async () => {
+    const containerRef = ref<HTMLElement | null>(null)
+    const isActive = ref(false)
+    const wrapper = mount(makeHost(containerRef, isActive), { attachTo: document.body })
+
+    expect(document.activeElement).toBe(externalButton)
+
+    isActive.value = true
+    await nextTick()
+    await nextTick()
+    expect(document.activeElement).not.toBe(externalButton)
+
+    isActive.value = false
+    await nextTick()
+    expect(document.activeElement).toBe(externalButton)
+
+    wrapper.unmount()
+  })
+
+  it('wraps focus from last to first on Tab', async () => {
+    const containerRef = ref<HTMLElement | null>(null)
+    const isActive = ref(false)
+    const wrapper = mount(makeHost(containerRef, isActive), { attachTo: document.body })
+
+    isActive.value = true
+    await nextTick()
+    await nextTick()
+
+    const last = wrapper.get('#last').element as HTMLElement
+    const first = wrapper.get('#first').element as HTMLElement
+    last.focus()
+
+    const event = new KeyboardEvent('keydown', { key: 'Tab', cancelable: true })
+    document.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(document.activeElement).toBe(first)
+
+    wrapper.unmount()
+  })
+
+  it('wraps focus from first to last on Shift+Tab', async () => {
+    const containerRef = ref<HTMLElement | null>(null)
+    const isActive = ref(false)
+    const wrapper = mount(makeHost(containerRef, isActive), { attachTo: document.body })
+
+    isActive.value = true
+    await nextTick()
+    await nextTick()
+
+    const first = wrapper.get('#first').element as HTMLElement
+    const last = wrapper.get('#last').element as HTMLElement
+    first.focus()
+
+    const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, cancelable: true })
+    document.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(document.activeElement).toBe(last)
+
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary
- Add reusable `useFocusTrap` composable (cache trigger, cycle Tab inside container, restore focus on close, Escape callback, SSR-safe) and wire it into the mobile drawer in `Header.vue` so keyboard and screen reader users can no longer Tab out of the modal and can close it with Escape.
- Flip `nuxt.config.ts` image provider from `'none'` to `'ipx'` so `@nuxt/image` actually generates responsive/optimized output via the bundled local optimizer (no new deps).
- Add explicit `loading="lazy"` to the below-the-fold project hero `NuxtImg` in `pages/projects/[id].vue`. Home `Hero.vue` keeps `loading="eager"` for the above-the-fold avatar.

## Test plan
- [x] `yarn test` — 37 files / 257 tests pass, including 6 new tests for `useFocusTrap` (inactive=no listener, first-focus on activate, Escape callback, focus restoration, Tab wrap, Shift+Tab wrap).
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual: open mobile drawer, verify focus lands on first item, Tab cycles, Escape closes, and focus returns to the toggle button.
- [ ] Manual: load `/projects/<slug>` in prod build and confirm the hero image is served via `/_ipx/...` with a `srcset`.
- [ ] Manual: verify SSR meta tags render in `view-source:` (remaining item in #67 that can't be auto-resolved here).

Refs #67