### PR TITLE
🚀 Release 1.10.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.10.8] - 2026-05-14
+
+### Fixed
+- **Prod runtime env wiring** — Wired `NUXT_API_BASE_URL` / `NUXT_API_BASE_PATH` / `NUXT_API_TOKEN` into `compose.prod.yml` with `:?` guards. v1.10.7 dropped the hardcoded fallbacks in `runtimeConfig` but the compose was never updated to pass them, so server-side `$fetch` in `projects.get.ts` / `profile.get.ts` resolved to relative paths and looped back into Nitro, allocating ~30 MB/s until the V8 heap cap killed the container ~130 s after start. (#99)
+- **Spotify env naming** — Renamed `SPOTIFY_*` → `NUXT_SPOTIFY_*` so Nuxt 3's `NUXT_`-prefix runtime override actually populates `runtimeConfig.spotify*`. Spotify credentials now reach the container. (#99)
+- **Container memory guard** — Added `mem_limit: 1g` and lowered `--max-old-space-size` from 4096 to 768 so a future regression dies cleanly via cgroup OOM instead of dragging the host. (#99)
+- **Type safety** — Replaced `as any` in `health.get.ts` with an `isHealthType` predicate; dropped `: any` in `projects.get.ts` via local narrowing. (#100, #68)
+
+### Added
+- **Mobile menu focus trap** — New `useFocusTrap` composable; the mobile nav drawer now traps Tab/Shift+Tab, closes on Escape, and restores focus to the trigger on close. Covered by 7 unit tests. (#101, #67)
+- **Image optimization** — Enabled the bundled `ipx` provider for `@nuxt/image`; below-fold images get explicit `loading="lazy"`. `Hero.vue` avatar stays `eager` as above-the-fold. (#101, #67)
+
+### Changed
+- **Code quality** — Extracted `DEFAULT_SCRAMBLE_SPEED_MS`, `DEFAULT_MAX_ITERATIONS`, `OBSERVER_THRESHOLD` constants in `DecryptedText.vue` (no more inline magic numbers); normalized `<script setup lang="ts">` attribute order across 12 .vue files. (#100, #68)
+
+---
+
 ## [1.10.7] - 2026-05-14
 
 ### Fixed

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -80,6 +80,6 @@ export default defineNuxtConfig({
   modules,
   builder: "vite",
   image: {
-    provider: 'none',
+    provider: 'ipx',
   },
 })

--- a/src/components/DecryptedText.vue
+++ b/src/components/DecryptedText.vue
@@ -26,6 +26,10 @@
 <script setup lang="ts">
 import { ref, watch, onMounted, onBeforeUnmount, computed, nextTick, type Ref } from 'vue'
 
+const DEFAULT_SCRAMBLE_SPEED_MS = 50
+const DEFAULT_MAX_ITERATIONS = 10
+const OBSERVER_THRESHOLD = 0.1
+
 interface Props {
     text: string
     speed?: number
@@ -41,8 +45,8 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), {
-    speed: 50,
-    maxIterations: 10,
+    speed: DEFAULT_SCRAMBLE_SPEED_MS,
+    maxIterations: DEFAULT_MAX_ITERATIONS,
     sequential: false,
     revealDirection: 'start',
     useOriginalCharsOnly: false,
@@ -206,7 +210,7 @@ onMounted(async () => {
         const observerOptions = {
             root: null,
             rootMargin: '0px',
-            threshold: 0.1,
+            threshold: OBSERVER_THRESHOLD,
         }
 
         observer = new window.IntersectionObserver(observerCallback, observerOptions)

--- a/src/components/home/Contact.vue
+++ b/src/components/home/Contact.vue
@@ -42,7 +42,7 @@
   </div>
 </template>
 
-<script lang="ts" setup>
+<script setup lang="ts">
 import { useContactForm } from '~/composables/useContactForm';
 
 const { form, loading, error, submitForm } = useContactForm();

--- a/src/components/home/Hero.vue
+++ b/src/components/home/Hero.vue
@@ -90,5 +90,5 @@
     </div>
 </template>
 
-<script lang="ts" setup>
+<script setup lang="ts">
 </script>

--- a/src/components/home/LatestPosts.vue
+++ b/src/components/home/LatestPosts.vue
@@ -47,7 +47,7 @@
   </div>
 </template>
 
-<script lang="ts" setup>
+<script setup lang="ts">
 interface BlogPost {
   title: string
   url: string

--- a/src/components/home/portfolio/PortfolioSection.vue
+++ b/src/components/home/portfolio/PortfolioSection.vue
@@ -38,7 +38,7 @@
   </div>
 </template>
 
-<script lang="ts" setup>
+<script setup lang="ts">
 import FeatureProjectCard from '~/components/home/portfolio/FeatureProjectCard.vue'
 
 // Fetch featured projects on server-side

--- a/src/components/main/Footer.vue
+++ b/src/components/main/Footer.vue
@@ -65,7 +65,7 @@
   </footer>
 </template>
 
-<script lang="ts" setup>
+<script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue';
 
 const { nowPlaying } = useNowPlaying();

--- a/src/components/main/Header.vue
+++ b/src/components/main/Header.vue
@@ -87,7 +87,7 @@
   </header>
 </template>
 
-<script lang="ts" setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { useRoute } from 'vue-router';
 

--- a/src/components/main/Header.vue
+++ b/src/components/main/Header.vue
@@ -54,6 +54,7 @@
     >
       <div
         v-if="isMenuOpen"
+        ref="drawerRef"
         class="fixed inset-0 bg-void/95 z-20 flex flex-col items-center justify-center md:hidden"
         role="dialog"
         aria-modal="true"
@@ -90,8 +91,11 @@
 <script lang="ts" setup>
 import { ref } from 'vue';
 import { useRoute } from 'vue-router';
+import { useFocusTrap } from '~/composables/useFocusTrap';
 
 const isMenuOpen = ref(false);
+const drawerRef = ref<HTMLElement | null>(null);
+useFocusTrap(drawerRef, isMenuOpen, () => (isMenuOpen.value = false));
 
 const navItems = ref([
   { label: 'Home', path: '/' },

--- a/src/components/ui/HealthBadge.vue
+++ b/src/components/ui/HealthBadge.vue
@@ -15,7 +15,7 @@
   </div>
 </template>
 
-<script lang="ts" setup>
+<script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import StatusIndicator from './StatusIndicator.vue'
 

--- a/src/composables/useFocusTrap.ts
+++ b/src/composables/useFocusTrap.ts
@@ -1,0 +1,108 @@
+import { nextTick, onScopeDispose, watch, type Ref } from 'vue'
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+  'input:not([disabled])',
+  'textarea:not([disabled])',
+  'select:not([disabled])',
+].join(', ')
+
+function getFocusable(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+}
+
+export function useFocusTrap(
+  containerRef: Ref<HTMLElement | null>,
+  isActive: Ref<boolean>,
+  onEscape?: () => void,
+): void {
+  // SSR-safe: bail out on the server.
+  if (typeof document === 'undefined') return
+
+  let previouslyFocused: HTMLElement | null = null
+  let keydownHandler: ((e: KeyboardEvent) => void) | null = null
+
+  function detach() {
+    if (keydownHandler) {
+      document.removeEventListener('keydown', keydownHandler)
+      keydownHandler = null
+    }
+  }
+
+  function activate() {
+    previouslyFocused = (document.activeElement as HTMLElement | null) ?? null
+
+    nextTick(() => {
+      const container = containerRef.value
+      if (!container) return
+      const focusable = getFocusable(container)
+      if (focusable.length > 0) {
+        focusable[0]?.focus()
+      } else {
+        // Fall back to focusing the container itself so the trap holds.
+        container.focus?.()
+      }
+    })
+
+    keydownHandler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onEscape?.()
+        return
+      }
+      if (e.key !== 'Tab') return
+
+      const container = containerRef.value
+      if (!container) return
+      const focusable = getFocusable(container)
+      if (focusable.length === 0) {
+        e.preventDefault()
+        return
+      }
+      const first = focusable[0]!
+      const last = focusable[focusable.length - 1]!
+      const active = document.activeElement as HTMLElement | null
+
+      if (e.shiftKey) {
+        if (active === first || !container.contains(active)) {
+          e.preventDefault()
+          last.focus()
+        }
+      } else {
+        if (active === last || !container.contains(active)) {
+          e.preventDefault()
+          first.focus()
+        }
+      }
+    }
+
+    document.addEventListener('keydown', keydownHandler)
+  }
+
+  function deactivate() {
+    detach()
+    const target = previouslyFocused
+    previouslyFocused = null
+    if (target && document.contains(target)) {
+      target.focus()
+    }
+  }
+
+  watch(
+    isActive,
+    (active, _prev) => {
+      if (active) {
+        activate()
+      } else {
+        deactivate()
+      }
+    },
+    { immediate: true },
+  )
+
+  onScopeDispose(() => {
+    detach()
+    previouslyFocused = null
+  })
+}

--- a/src/composables/useProjects.ts
+++ b/src/composables/useProjects.ts
@@ -37,6 +37,7 @@ export function useProjects(): UseProjectsReturn {
         } catch (err) {
             const errorObj = err instanceof Error ? err : new Error(String(err))
             error.value = errorObj
+            // Re-throw so useAsyncData callers see the error state.
             throw err
         } finally {
             loading.value = false
@@ -55,6 +56,7 @@ export function useProjects(): UseProjectsReturn {
         } catch (err) {
             const errorObj = err instanceof Error ? err : new Error(String(err))
             error.value = errorObj
+            // Re-throw so useAsyncData callers see the error state.
             throw err
         } finally {
             loading.value = false

--- a/src/pages/about.vue
+++ b/src/pages/about.vue
@@ -192,7 +192,7 @@
   </div>
 </template>
 
-<script lang="ts" setup>
+<script setup lang="ts">
 import { computed } from 'vue';
 import LatestPosts from '@/components/home/LatestPosts.vue';
 import type { Profile } from '~/types/profile';

--- a/src/pages/health.vue
+++ b/src/pages/health.vue
@@ -87,7 +87,7 @@
   </div>
 </template>
 
-<script lang="ts" setup>
+<script setup lang="ts">
 import { ref, computed, watch } from 'vue'
 import StatusIndicator from '~/components/ui/StatusIndicator.vue'
 import MetaInfoPair from '~/components/ui/MetaInfoPair.vue'

--- a/src/pages/now.vue
+++ b/src/pages/now.vue
@@ -200,7 +200,7 @@
   </div>
 </template>
 
-<script lang="ts" setup>
+<script setup lang="ts">
 const lastUpdated = '2026-05-01';
 
 const { nowPlaying } = useNowPlaying();

--- a/src/pages/projects/[id].vue
+++ b/src/pages/projects/[id].vue
@@ -176,7 +176,7 @@
   </div>
 </template>
 
-<script lang="ts" setup>
+<script setup lang="ts">
 import { ref, watch } from 'vue'
 
 const route = useRoute()

--- a/src/pages/projects/[id].vue
+++ b/src/pages/projects/[id].vue
@@ -61,6 +61,7 @@
           :alt="`${project.title} screenshot`"
           class="w-full h-full object-cover"
           sizes="sm:100vw md:1200px lg:1200px"
+          loading="lazy"
           placeholder
           @error="() => (imageError = true)"
         />

--- a/src/pages/projects/index.vue
+++ b/src/pages/projects/index.vue
@@ -99,7 +99,7 @@
   </div>
 </template>
 
-<script lang="ts" setup>
+<script setup lang="ts">
 import { useProjects } from '~/composables/useProjects'
 
 usePageTitle('Case Files', {

--- a/src/server/api/health.get.ts
+++ b/src/server/api/health.get.ts
@@ -6,7 +6,9 @@ export default defineEventHandler(async (event) => {
 
   // Validate type against allowlist to prevent SSRF path traversal
   const allowedTypes = ['basic', 'detailed', 'live', 'ready'] as const
-  const type = allowedTypes.includes(rawType as any) ? rawType : 'basic'
+  type HealthType = typeof allowedTypes[number]
+  const isHealthType = (v: string): v is HealthType => (allowedTypes as readonly string[]).includes(v)
+  const type: HealthType = isHealthType(rawType) ? rawType : 'basic'
 
   const headers: Record<string, string> = {}
   if (config.apiToken) {

--- a/src/server/api/projects.get.ts
+++ b/src/server/api/projects.get.ts
@@ -15,12 +15,15 @@ export default defineEventHandler(async (event) => {
 
   // Normalize techStack to always be string[]
   if (data?.data && Array.isArray(data.data)) {
-    data.data = data.data.map((project: any) => ({
-      ...project,
-      techStack: Array.isArray(project.techStack)
-        ? project.techStack
-        : project.techStack ? [String(project.techStack)] : [],
-    }))
+    data.data = data.data.map((project) => {
+      const techStack = project.techStack
+      return {
+        ...project,
+        techStack: Array.isArray(techStack)
+          ? techStack
+          : techStack ? [String(techStack)] : [],
+      }
+    })
   }
 
   return data

--- a/tests/composables/useFocusTrap.test.ts
+++ b/tests/composables/useFocusTrap.test.ts
@@ -164,4 +164,27 @@ describe('useFocusTrap', () => {
 
     wrapper.unmount()
   })
+
+  it('detaches the keydown listener when unmounted while active', async () => {
+    const containerRef = ref<HTMLElement | null>(null)
+    const isActive = ref(false)
+    const onEscape = vi.fn()
+    const wrapper = mount(makeHost(containerRef, isActive, onEscape), {
+      attachTo: document.body,
+    })
+
+    isActive.value = true
+    await nextTick()
+    await nextTick()
+
+    // Sanity check: listener is wired up.
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(onEscape).toHaveBeenCalledTimes(1)
+
+    wrapper.unmount()
+
+    // After unmount, no further keydown should reach the trap.
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(onEscape).toHaveBeenCalledTimes(1)
+  })
 })

--- a/tests/composables/useFocusTrap.test.ts
+++ b/tests/composables/useFocusTrap.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { defineComponent, h, nextTick, ref, type Ref } from 'vue'
+import { mount } from '@vue/test-utils'
+
+const { useFocusTrap } = await import('~/composables/useFocusTrap')
+
+function makeHost(
+  containerRef: Ref<HTMLElement | null>,
+  isActive: Ref<boolean>,
+  onEscape?: () => void,
+) {
+  return defineComponent({
+    setup() {
+      useFocusTrap(containerRef, isActive, onEscape)
+      return () =>
+        h(
+          'div',
+          {
+            ref: (el) => {
+              containerRef.value = el as HTMLElement | null
+            },
+            tabindex: -1,
+          },
+          [
+            h('button', { id: 'first' }, 'first'),
+            h('a', { id: 'middle', href: '#' }, 'middle'),
+            h('button', { id: 'last' }, 'last'),
+          ],
+        )
+    },
+  })
+}
+
+describe('useFocusTrap', () => {
+  let externalButton: HTMLButtonElement
+
+  beforeEach(() => {
+    // External focusable element to simulate the trigger (so we can verify restoration).
+    externalButton = document.createElement('button')
+    externalButton.id = 'trigger'
+    document.body.appendChild(externalButton)
+    externalButton.focus()
+  })
+
+  afterEach(() => {
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild)
+    }
+  })
+
+  it('does not attach keydown listener while inactive', () => {
+    const addSpy = vi.spyOn(document, 'addEventListener')
+    const containerRef = ref<HTMLElement | null>(null)
+    const isActive = ref(false)
+    const onEscape = vi.fn()
+
+    const wrapper = mount(makeHost(containerRef, isActive, onEscape), {
+      attachTo: document.body,
+    })
+
+    const keydownCalls = addSpy.mock.calls.filter(([type]) => type === 'keydown')
+    expect(keydownCalls).toHaveLength(0)
+
+    // Dispatching escape should be a no-op.
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(onEscape).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+    addSpy.mockRestore()
+  })
+
+  it('focuses the first focusable element when activated', async () => {
+    const containerRef = ref<HTMLElement | null>(null)
+    const isActive = ref(false)
+    const wrapper = mount(makeHost(containerRef, isActive), { attachTo: document.body })
+
+    isActive.value = true
+    await nextTick()
+    await nextTick()
+
+    const first = wrapper.get('#first').element as HTMLElement
+    expect(document.activeElement).toBe(first)
+
+    wrapper.unmount()
+  })
+
+  it('invokes the onEscape callback when Escape is pressed', async () => {
+    const containerRef = ref<HTMLElement | null>(null)
+    const isActive = ref(false)
+    const onEscape = vi.fn()
+    const wrapper = mount(makeHost(containerRef, isActive, onEscape), {
+      attachTo: document.body,
+    })
+
+    isActive.value = true
+    await nextTick()
+    await nextTick()
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(onEscape).toHaveBeenCalledTimes(1)
+
+    wrapper.unmount()
+  })
+
+  it('restores focus to the previously focused element on deactivation', async () => {
+    const containerRef = ref<HTMLElement | null>(null)
+    const isActive = ref(false)
+    const wrapper = mount(makeHost(containerRef, isActive), { attachTo: document.body })
+
+    expect(document.activeElement).toBe(externalButton)
+
+    isActive.value = true
+    await nextTick()
+    await nextTick()
+    expect(document.activeElement).not.toBe(externalButton)
+
+    isActive.value = false
+    await nextTick()
+    expect(document.activeElement).toBe(externalButton)
+
+    wrapper.unmount()
+  })
+
+  it('wraps focus from last to first on Tab', async () => {
+    const containerRef = ref<HTMLElement | null>(null)
+    const isActive = ref(false)
+    const wrapper = mount(makeHost(containerRef, isActive), { attachTo: document.body })
+
+    isActive.value = true
+    await nextTick()
+    await nextTick()
+
+    const last = wrapper.get('#last').element as HTMLElement
+    const first = wrapper.get('#first').element as HTMLElement
+    last.focus()
+
+    const event = new KeyboardEvent('keydown', { key: 'Tab', cancelable: true })
+    document.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(document.activeElement).toBe(first)
+
+    wrapper.unmount()
+  })
+
+  it('wraps focus from first to last on Shift+Tab', async () => {
+    const containerRef = ref<HTMLElement | null>(null)
+    const isActive = ref(false)
+    const wrapper = mount(makeHost(containerRef, isActive), { attachTo: document.body })
+
+    isActive.value = true
+    await nextTick()
+    await nextTick()
+
+    const first = wrapper.get('#first').element as HTMLElement
+    const last = wrapper.get('#last').element as HTMLElement
+    first.focus()
+
+    const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, cancelable: true })
+    document.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(document.activeElement).toBe(last)
+
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary

Stabilization release. Restores prod after the v1.10.4–1.10.7 OOM regression, plus accessibility and code-quality follow-ups from the most recent code review pass.

## Highlights

### Fixed (#99 — root cause of cativo.dev outage)
- Wired `NUXT_API_BASE_URL` / `NUXT_API_BASE_PATH` / `NUXT_API_TOKEN` into `compose.prod.yml` with required-guard syntax. v1.10.7 had removed the hardcoded fallbacks in `nuxt.config.ts` but the compose was never updated to pass them — server-side `$fetch` resolved to relative paths and looped back into Nitro, OOMing the container ~130 s after start.
- Renamed `SPOTIFY_*` → `NUXT_SPOTIFY_*` so Nuxt 3's `NUXT_`-prefix runtime override actually populates the runtime config. Spotify credentials now reach the container.
- Added `mem_limit: 1g` and lowered `--max-old-space-size` from 4096 → 768 for defense-in-depth.

### Accessibility & a11y (#101 — closes #67 actionable items)
- New `useFocusTrap` composable. Mobile drawer now traps Tab / Shift+Tab, closes on Escape, restores focus to the trigger.
- Enabled `ipx` image provider; explicit `loading="lazy"` on below-fold images.
- 7 new unit tests for `useFocusTrap`, including listener cleanup on unmount-while-active.

### Code quality (#100 — closes #68 actionable items)
- Removed `as any` from `health.get.ts` and `projects.get.ts` via narrowing.
- Extracted magic numbers in `DecryptedText.vue` to named constants.
- Normalized `<script setup lang="ts">` attribute order across 12 .vue files.
- Documented intentional re-throw in `useProjects` (needed by `useAsyncData` callers).

## Validation

- Tests: 258 / 258 passing (37 files)
- TypeScript: `tsc --noEmit` clean
- Live verification on polaris2 (#99 deployed as a hotfix earlier today): `cativo.dev` returns 200, `/api/spotify/now-playing` returns real track data, container healthy at ~28 MiB

## Test plan

- [x] CI `build` job green
- [x] `compose.prod.yml` already running on polaris2 with these values (smoke-tested live)
- [ ] Post-merge: confirm auto-release workflow tags `v1.10.8` and Docker image builds
- [ ] Post-merge: confirm deploy workflow updates the container on polaris2
- [ ] Post-release: merge `main` back into `develop`

## Issues this closes the loop on

- Closes the prod runtime env story opened by #99 (already merged to develop)
- Bundles the #67 / #68 follow-ups closed today

Refs #67 #68 #99 #100 #101