### PR TITLE
fix(deploy): tighten prod compose per security audit

### DIFF
--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -17,9 +17,9 @@ services:
       NUXT_SPOTIFY_CLIENT_SECRET: ${NUXT_SPOTIFY_CLIENT_SECRET:-}
       NUXT_SPOTIFY_REFRESH_TOKEN: ${NUXT_SPOTIFY_REFRESH_TOKEN:-}
     healthcheck:
-      test: ["CMD", "node", "-e", "fetch('http://localhost:3000').then(r => { if (!r.ok) process.exit(1) }).catch(() => process.exit(1))"]
+      test: ["CMD", "wget", "-q", "--spider", "--tries=1", "http://localhost:3000"]
       interval: 30s
-      timeout: 15s
+      timeout: 10s
       start_period: 30s
       retries: 3
     labels:
@@ -27,8 +27,8 @@ services:
       - "traefik.http.routers.portfolio.rule=Host(`cativo.dev`)"
       - "traefik.http.routers.portfolio.entrypoints=websecure"
       - "traefik.http.routers.portfolio.tls.certresolver=letsencryptresolver"
+      - "traefik.http.routers.portfolio.middlewares=security-headers@file"
       - "traefik.http.services.portfolio.loadbalancer.server.port=3000"
-      - "traefik.docker.network=space-server_web"
     networks:
       - space-server_web
 networks:


### PR DESCRIPTION
## Summary

Closes the three items in #55:

1. **Healthcheck** — `node -e 'fetch(...)'` → `wget -q --spider`. Same coverage (any non-2xx exits non-zero), but no JS engine startup every 30s. Timeout tightened 15s → 10s since wget returns in ~5ms when healthy.
2. **Security headers** — Added `traefik.http.routers.portfolio.middlewares=security-headers@file` label. The middleware is already defined in `space-server/traefik/dynamic/auth.yml` (HSTS 1y + includeSubdomains, X-Frame-Options DENY, nosniff, X-XSS).
3. **Redundant `traefik.docker.network`** — Removed. The container is on a single network (`space-server_web`); Traefik auto-detects.

## Test plan

- [x] `docker compose -f compose.prod.yml config` validates
- [ ] Post-merge: confirm `curl -I https://cativo.dev/` shows `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`
- [ ] Post-merge: container reports `healthy` with the wget healthcheck
- [ ] Post-merge: no Traefik routing regressions (cativo.dev still serves 200)

Closes #55