### PR TITLE
🚀 Release 1.10.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.10.9] - 2026-05-14
+
+### Added
+- **Global error page** — New `src/error.vue` (Nuxt 3 picks it up automatically). Renders uncaught errors and 404s in the Nightwire idiom (panel + compressed `[ERR-xxx]` title) inside `NuxtLayout`. Return-to-base button calls `clearError({ redirect: '/' })`. (#104, #30)
+- **`BaseAsyncState` panel variant** — Non-breaking addition: `variant: 'plain' | 'panel'`, `panelHeader`, and `errorCode` props. Panel variant renders the full Nightwire shell so future adopters get the idiom for free. Loading branch now sets `role="status"`. JSDoc documents it as the canonical async wrapper, satisfying the `LoadingSpinner` / `ErrorMessage` intent of #30 under one component. (#104, #30)
+- **Traefik security headers** — `traefik.http.routers.portfolio.middlewares=security-headers@file` label wired to the existing space-server middleware. HSTS (1y + includeSubdomains), X-Frame-Options DENY, X-Content-Type-Options nosniff, X-XSS-Protection now enforced on `cativo.dev`. (#103, #55)
+
+### Changed
+- **Healthcheck** — `compose.prod.yml` switches from a Node.js process (`node -e fetch(...)`) to busybox `wget -q --spider`. Same coverage (any non-2xx exits non-zero), near-zero CPU/memory cost, faster timeout (15s → 10s). (#103, #55)
+- **Compose hygiene** — Dropped the redundant `traefik.docker.network=space-server_web` label. The service is on a single network; Traefik auto-detects. (#103, #55)
+
+---
+
 ## [1.10.8] - 2026-05-14
 
 ### Fixed

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -17,9 +17,9 @@ services:
       NUXT_SPOTIFY_CLIENT_SECRET: ${NUXT_SPOTIFY_CLIENT_SECRET:-}
       NUXT_SPOTIFY_REFRESH_TOKEN: ${NUXT_SPOTIFY_REFRESH_TOKEN:-}
     healthcheck:
-      test: ["CMD", "node", "-e", "fetch('http://localhost:3000').then(r => { if (!r.ok) process.exit(1) }).catch(() => process.exit(1))"]
+      test: ["CMD", "wget", "-q", "--spider", "--tries=1", "http://localhost:3000"]
       interval: 30s
-      timeout: 15s
+      timeout: 10s
       start_period: 30s
       retries: 3
     labels:
@@ -27,8 +27,8 @@ services:
       - "traefik.http.routers.portfolio.rule=Host(`cativo.dev`)"
       - "traefik.http.routers.portfolio.entrypoints=websecure"
       - "traefik.http.routers.portfolio.tls.certresolver=letsencryptresolver"
+      - "traefik.http.routers.portfolio.middlewares=security-headers@file"
       - "traefik.http.services.portfolio.loadbalancer.server.port=3000"
-      - "traefik.docker.network=space-server_web"
     networks:
       - space-server_web
 networks:

--- a/src/components/base/AsyncState.vue
+++ b/src/components/base/AsyncState.vue
@@ -1,3 +1,17 @@
+<!--
+  AsyncState is the canonical loading/error/empty wrapper for async data in
+  this project. It satisfies issue #30: instead of separate LoadingSpinner
+  and ErrorMessage components, a single slotted wrapper handles all three
+  states with consistent semantics (role="status" / role="alert") and
+  optional Nightwire panel chrome for in-page placement.
+
+  Variants:
+  - `plain` (default) — renders centered text; use inside an existing panel.
+  - `panel` — renders the full Nightwire panel shell (header + body); use
+    when AsyncState is the top-level UI of a page section.
+
+  For global uncaught errors, see `src/error.vue` (Nuxt 3 error page).
+-->
 <script setup lang="ts">
 import { computed } from 'vue'
 
@@ -8,12 +22,17 @@ interface Props {
   loadingText?: string
   errorText?: string
   emptyText?: string
+  variant?: 'plain' | 'panel'
+  panelHeader?: string
+  errorCode?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
   loadingText: 'Loading...',
   errorText: 'An error occurred',
-  emptyText: 'No data available'
+  emptyText: 'No data available',
+  variant: 'plain',
+  panelHeader: 'STATUS',
 })
 
 defineSlots<{
@@ -29,11 +48,38 @@ const sanitizedError = computed(() => {
   if (typeof props.error === 'string') return props.error
   return props.error.message || 'An unexpected error occurred'
 })
+
+const isPanel = computed(() => props.variant === 'panel')
+const stateClasses = computed(() => isPanel.value ? 'panel-body p-12 text-center' : 'text-center py-8')
 </script>
 
 <template>
-  <div>
-    <div v-if="loading" class="text-center py-8" aria-live="polite">
+  <div v-if="isPanel" class="panel">
+    <div class="panel-header">
+      <span>{{ panelHeader }}</span>
+    </div>
+    <div v-if="loading" :class="stateClasses" role="status" aria-live="polite">
+      <slot name="loading">
+        <p class="text-nw-text-dim font-stamp uppercase tracking-wider text-xs">{{ loadingText }}</p>
+      </slot>
+    </div>
+    <div v-else-if="error" :class="stateClasses" role="alert">
+      <slot name="error" :error="error">
+        <p class="text-nw-red font-stamp uppercase tracking-wider text-xs">
+          <span v-if="errorCode">[ERR-{{ errorCode }}] </span>{{ sanitizedError ?? errorText }}
+        </p>
+      </slot>
+    </div>
+    <div v-else-if="empty" :class="stateClasses">
+      <slot name="empty">
+        <p class="text-nw-text-dim font-stamp uppercase tracking-wider text-xs">{{ emptyText }}</p>
+      </slot>
+    </div>
+    <slot v-else />
+  </div>
+
+  <div v-else>
+    <div v-if="loading" class="text-center py-8" role="status" aria-live="polite">
       <slot name="loading">
         <p class="text-nw-text-dim">{{ loadingText }}</p>
       </slot>
@@ -41,7 +87,7 @@ const sanitizedError = computed(() => {
 
     <div v-else-if="error" class="text-center py-8 text-nw-red" role="alert">
       <slot name="error" :error="error">
-        <p>{{ sanitizedError ?? errorText }}</p>
+        <p><span v-if="errorCode">[ERR-{{ errorCode }}] </span>{{ sanitizedError ?? errorText }}</p>
       </slot>
     </div>
 

--- a/src/error.vue
+++ b/src/error.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { NuxtError } from '#app'
+
+const props = defineProps<{ error: NuxtError }>()
+
+const statusCode = computed(() => Number(props.error.statusCode) || 500)
+const isNotFound = computed(() => statusCode.value === 404)
+
+const headerLabel = computed(() => isNotFound.value ? 'CHANNEL LOST · ERR-404' : `MISSION ABORT · ERR-${statusCode.value}`)
+const stamp = computed(() => isNotFound.value ? '通信途絶' : '任務中断')
+
+const headline = computed(() => isNotFound.value ? 'Case file not found' : 'Unexpected failure')
+const detail = computed(() => {
+  if (isNotFound.value) return "The path you requested doesn't exist or has been moved."
+  return props.error.statusMessage || props.error.message || 'Something failed on our side. The signal will recover.'
+})
+
+function returnToBase() {
+  clearError({ redirect: '/' })
+}
+
+useSeoMeta({
+  title: `ERR-${statusCode.value}`,
+  robots: 'noindex, nofollow',
+})
+</script>
+
+<template>
+  <NuxtLayout>
+    <div class="space-y-0.5 pb-12">
+      <div class="panel">
+        <div class="panel-header">
+          <span>{{ headerLabel }}</span>
+          <span class="tag">{{ stamp }}</span>
+        </div>
+        <div class="panel-body p-12 text-center" role="alert">
+          <h1
+            class="compressed-title text-nw-text leading-[1] mb-4"
+            style="font-size: clamp(48px, 9vw, 96px);"
+          >
+            [ERR-{{ statusCode }}]
+          </h1>
+          <p class="font-stamp uppercase tracking-wider text-xs text-nw-red mb-4">
+            {{ headline }}
+          </p>
+          <p class="text-nw-text-dim leading-relaxed max-w-md mx-auto mb-8">
+            {{ detail }}
+          </p>
+          <BaseButton variant="ghost" @click="returnToBase">
+            <LucideArrowLeft class="w-4 h-4 mr-2" />
+            Return to base
+          </BaseButton>
+        </div>
+      </div>
+    </div>
+  </NuxtLayout>
+</template>


### PR DESCRIPTION
## Summary

Quality + infra patch on top of 1.10.8. No prod behavior change other than what's in the bullets.

## Highlights

### Added
- Global `src/error.vue` for uncaught errors and 404s, styled in the Nightwire idiom (#104, #30).
- `BaseAsyncState` gains a non-breaking \`panel\` variant + \`errorCode\` prop (#104, #30).
- Traefik \`security-headers@file\` middleware on cativo.dev — HSTS, X-Frame-Options DENY, nosniff, XSS filter (#103, #55).

### Changed
- Healthcheck switched from Node fetch to busybox \`wget --spider\` — near-zero CPU, 10s timeout (#103, #55).
- Removed redundant \`traefik.docker.network\` label (#103, #55).

## Test plan

- [x] CI \`build\` green on both source PRs (#103, #104)
- [ ] Post-merge: tag \`v1.10.9\` + GitHub Release created by auto-release workflow
- [ ] Post-merge: Deploy workflow updates polaris2 container successfully
- [ ] Post-deploy: \`curl -I https://cativo.dev/\` shows \`Strict-Transport-Security\`, \`X-Frame-Options\`, \`X-Content-Type-Options\`
- [ ] Post-deploy: container reports \`healthy\` with wget healthcheck
- [ ] Post-deploy: hitting a non-existent route renders the new Nightwire error page
- [ ] Post-release: merge \`main\` back to \`develop\`

Refs #30 #55 #103 #104