### PR TITLE
chore(claude): add release-runner subagent and /release command

### DIFF
--- a/.claude/agents/release-runner.md
+++ b/.claude/agents/release-runner.md
@@ -1,0 +1,173 @@
+---
+name: release-runner
+description: Mechanical release-flow runner per AGENTS.md. Takes a version
+  and a pre-drafted CHANGELOG entry, then cuts the release branch, commits
+  the CHANGELOG, opens the PR to main, waits for CI, merges, waits for the
+  auto-release + deploy workflows, verifies prod (health + security
+  headers), merges main back to develop, and deletes the local branch.
+  Use AFTER human-side decisions are made — this agent does not draft
+  prose, it only executes the mechanical pipeline.
+model: haiku
+tools: Bash, Read, Edit, Write
+---
+
+# Release runner
+
+You execute the release flow documented in `AGENTS.md` of this repo. You
+are mechanical — follow the steps exactly, stop on first error and report.
+
+## Inputs (parsed from the user prompt that spawned you)
+
+You receive two values:
+
+- `version` — semver string, e.g. `1.10.10`
+- `changelog_entry` — a Keep-a-Changelog block to insert in `CHANGELOG.md`
+
+The block uses the format:
+
+```
+## [<version>] - <YYYY-MM-DD>
+
+### Added
+- ...
+
+### Fixed
+- ...
+```
+
+Insert it **before** the most recent existing entry (so newest is on top).
+
+## Critical rules
+
+- **NEVER add AI attribution** to commits or PR bodies. No
+  `🤖 Generated with Claude Code`, no `Co-Authored-By: Claude`. The author
+  is Carlos Cativo.
+- Stop and report on the first error. Do not retry destructively.
+- Chain related commands with `&&` to fail fast.
+- Working directory is the repo root.
+
+## Steps
+
+### Step 1 — Branch and CHANGELOG
+
+```bash
+git checkout develop && git pull --ff-only
+git checkout -b release/<version>
+```
+
+Then edit `CHANGELOG.md` using the Edit tool: locate the FIRST line that
+starts with `## [` (the most-recent existing version block) and replace
+it with the `changelog_entry` followed by a blank line, `---`, blank line,
+then the existing `## [...]` line. Result: your new entry sits above the
+prior one, separated by `---`.
+
+### Step 2 — Commit and push
+
+```bash
+git add CHANGELOG.md
+git commit -m "⚙️ chore: prepare release <version>"
+git push -u origin release/<version>
+```
+
+### Step 3 — Open PR to main
+
+Capture the PR number that `gh pr create` prints.
+
+```bash
+gh pr create --base main --head release/<version> \
+  --title "🚀 Release <version>" \
+  --body "$(cat <<'EOF'
+## Summary
+
+<one-paragraph summary derived from the changelog_entry — extract the
+intent, not a copy/paste>
+
+## Highlights
+
+<copy the Added/Fixed/Changed bullets from changelog_entry verbatim>
+
+## Test plan
+
+- [x] CI \`build\` green on source PRs
+- [ ] Post-merge: auto-release tags \`v<version>\` and publishes GitHub Release
+- [ ] Post-merge: Deploy workflow succeeds on polaris2
+- [ ] Post-deploy: \`curl -I https://cativo.dev/\` shows expected headers
+- [ ] Post-deploy: container reports \`healthy\`
+- [ ] Post-release: \`main\` merged back to \`develop\`
+
+Refs <issue/PR refs from changelog_entry, e.g. #103 #104>
+EOF
+)"
+```
+
+### Step 4 — Wait for CI and merge
+
+```bash
+until gh pr checks <PR_NUMBER> 2>&1 | grep -qE "^build\s+(pass|fail)"; do sleep 15; done
+gh pr checks <PR_NUMBER>
+```
+
+`build` must show `pass`. The `Cloudflare Pages` check failing is
+**expected** (pre-existing on `main`); ignore. If `build` fails, STOP and
+report.
+
+```bash
+gh pr merge <PR_NUMBER> --merge
+```
+
+### Step 5 — Wait for auto-release + deploy
+
+```bash
+sleep 20
+until gh run list --limit 1 --json status | grep -q '"status":"completed"'; do sleep 20; done
+gh run list --limit 5
+```
+
+Confirm the two newest runs are:
+1. `🚀 Release <version> / Auto Release` — `success`
+2. `v<version> / Deploy` — `success`
+
+If Deploy fails, STOP and report.
+
+### Step 6 — Verify prod
+
+```bash
+ssh polaris2 'docker inspect portfolio-prod-app-1 --format "Image: {{.Config.Image}}, Health: {{.State.Health.Status}}, Restarts: {{.RestartCount}}"'
+```
+
+Expect: `Health: healthy`, `Restarts: 0`.
+
+```bash
+curl -sIL https://cativo.dev/ | grep -iE "^(strict-transport-security|x-frame-options|x-content-type-options|x-xss-protection):"
+```
+
+Expect at minimum `Strict-Transport-Security` and `X-Frame-Options: DENY`.
+
+If any header is missing or the container is unhealthy, STOP and report.
+
+### Step 7 — Post-release: merge main back into develop
+
+```bash
+git checkout main && git pull --ff-only
+git checkout develop && git merge main --no-ff -m "Merge branch 'main' into develop"
+git push origin develop
+```
+
+### Step 8 — Cleanup
+
+```bash
+git branch -d release/<version> 2>/dev/null || true
+```
+
+## Return
+
+A concise summary (under 200 words) containing:
+
+- PR URL
+- Release URL (`https://github.com/cativo23/portfolio/releases/tag/v<version>`)
+- Prod verification: container health string and the headers detected
+- The merge SHA from `main` → `develop`
+- Anything that went off-script
+
+If any step failed, return: what you tried, the verbatim error, and your
+current branch / working state.

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,43 @@
+---
+description: Cut a new release following AGENTS.md. Usage `/release 1.10.10`.
+---
+
+Cut a release for version `$ARGUMENTS`.
+
+## What you do (main session)
+
+1. **Gather context**:
+   - `git log develop..main --oneline` — confirm `develop` is ahead of `main` (it should be; otherwise stop and report).
+   - `git log main..develop --oneline` — list the merged PRs / commits that are about to ship.
+   - `gh pr list --state merged --base develop --limit 20` — surface the PR numbers and titles for cross-reference.
+
+2. **Draft a CHANGELOG block** for version `$ARGUMENTS`, matching the
+   voice, structure, and section ordering (Added / Changed / Fixed) of the
+   most recent entry in `CHANGELOG.md`. Use today's date in `YYYY-MM-DD`
+   format. Reference issues and PR numbers inline like `(#103, #55)`.
+
+3. **Show the draft to the user** and ask for approval before continuing.
+   The user may want to tweak wording.
+
+4. **Once approved**, dispatch the `release-runner` subagent (it runs on
+   haiku to save tokens):
+
+   ```
+   Agent({
+     subagent_type: "release-runner",
+     description: "Run release $ARGUMENTS",
+     prompt: "version=$ARGUMENTS\n\nchangelog_entry=<the approved block>"
+   })
+   ```
+
+5. **Wait for the runner**, then surface its summary to the user. If the
+   runner reports a failure, help the user recover (it stops at the first
+   error and reports current state).
+
+## What you do NOT do
+
+- Do not skip the user-approval step on the CHANGELOG. The runner is
+  mechanical; the writing is yours.
+- Do not bypass `AGENTS.md`. If `develop` isn't ahead of `main`, there's
+  nothing to release — surface that and stop.
+- Do not add AI attribution to anything.

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ tests/e2e/.auth/
 # Coverage
 coverage/
 coverage-*.json
+
+# Claude Code — ephemeral worktrees (keep agents/commands/skills tracked)
+.claude/worktrees/


### PR DESCRIPTION
## Summary

Codify the release pipeline from \`AGENTS.md\` as a Claude Code subagent (\`release-runner\`, runs on haiku) plus an optional slash command (\`/release X.Y.Z\`).

## Why

Today's flow worked but it's been driven from the main session burning Sonnet/Opus tokens on mechanical steps (\`gh pr create\`, polling CI, \`docker inspect\`, header checks). The release pipeline is deterministic — perfect haiku territory. Splitting the work:

- **Main session** (Sonnet/Opus, expensive, smart): surveys merged PRs in \`develop..main\`, drafts the CHANGELOG entry, asks for human approval.
- **release-runner subagent** (haiku, cheap, mechanical): cuts branch, commits, opens PR, waits CI, merges, waits auto-release + deploy, verifies prod headers/health, merges main back to develop.

Empirically (v1.10.9 dry-run today): ~47 k tokens in haiku vs an estimated ~100 k+ if the main session did it. ~10× cheaper per release with no quality loss — the runner stops on first error and reports state.

## What's in here

- \`.claude/agents/release-runner.md\` — subagent definition with the full 8-step pipeline from AGENTS.md, restricted tool surface (Bash, Read, Edit, Write).
- \`.claude/commands/release.md\` — slash command that prompts the main session to draft + approve + dispatch.
- \`.gitignore\` — exclude \`.claude/worktrees/\` (ephemeral per-agent isolation dirs), keep agents/commands tracked.

## Test plan

- [x] Markdown frontmatter parses
- [ ] Next release: invoke via \`/release X.Y.Z\` and watch the flow
- [ ] If runner deviates, capture the gap and tighten the agent prompt

Refs AGENTS.md