### PR TITLE
release: v1.10.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.10.11] - 2026-05-21
+
+### Changed
+- Bump nightwire submodule to v2-alpha (530c4a8) — adds v2 semantic tokens,
+  intensity system, and new components while keeping all v1 classes intact.
+
+---
+
 ## [1.10.10] - 2026-05-15
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-app",
-  "version": "1.10.10",
+  "version": "1.10.11",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump nightwire submodule to v2-alpha (530c4a8)
- Smoke tested locally — no v1 regressions

## Changes
- `.nightwire` submodule: `54538ec` → `530c4a8` (v1.0.0 → v2-alpha)
- All existing tokens and classes intact (100% additive)