### PR TITLE
🐛 fix(composables): prevent duplicate now-playing intervals

### DIFF
--- a/src/composables/useNowPlaying.ts
+++ b/src/composables/useNowPlaying.ts
@@ -11,43 +11,45 @@ interface NowPlayingData {
   durationMs?: number
 }
 
+// Singletons so multiple components sharing this composable don't create duplicate intervals
+let _fetchInterval: ReturnType<typeof setInterval> | null = null
+let _progressInterval: ReturnType<typeof setInterval> | null = null
+let _activeConsumers = 0
+
 export function useNowPlaying() {
   const data = useState<NowPlayingData>('now-playing', () => ({ isPlaying: false }))
-  let lastFetchTime = 0
 
   async function fetchNowPlaying() {
     try {
       const result = await $fetch<NowPlayingData>('/api/spotify/now-playing')
       data.value = result
-      lastFetchTime = Date.now()
     } catch {
       data.value = { isPlaying: false }
     }
   }
 
   if (import.meta.client) {
-    let fetchInterval: ReturnType<typeof setInterval> | null = null
-    let progressInterval: ReturnType<typeof setInterval> | null = null
-
     onMounted(() => {
-      fetchNowPlaying()
-      fetchInterval = setInterval(fetchNowPlaying, 5_000)
+      _activeConsumers++
+      if (_activeConsumers === 1) {
+        fetchNowPlaying()
+        _fetchInterval = setInterval(fetchNowPlaying, 5_000)
 
-      // Interpolate progress smoothly between 5s polls
-      progressInterval = setInterval(() => {
-        if (data.value.isPlaying && data.value.progressMs !== undefined && data.value.durationMs !== undefined) {
-          const elapsed = Date.now() - lastFetchTime
-          // Add elapsed time to the base progress we got from the API, capping at duration
-          data.value.progressMs = Math.min(data.value.progressMs + 1000, data.value.durationMs)
-          // Update lastFetchTime so we only add 1s next tick
-          lastFetchTime = Date.now()
-        }
-      }, 1000)
+        // Interpolate progress between API polls (runs once, shared across all consumers)
+        _progressInterval = setInterval(() => {
+          if (data.value.isPlaying && data.value.progressMs !== undefined && data.value.durationMs !== undefined) {
+            data.value.progressMs = Math.min(data.value.progressMs + 1000, data.value.durationMs)
+          }
+        }, 1000)
+      }
     })
 
     onUnmounted(() => {
-      if (fetchInterval) clearInterval(fetchInterval)
-      if (progressInterval) clearInterval(progressInterval)
+      _activeConsumers--
+      if (_activeConsumers === 0) {
+        if (_fetchInterval) { clearInterval(_fetchInterval); _fetchInterval = null }
+        if (_progressInterval) { clearInterval(_progressInterval); _progressInterval = null }
+      }
     })
   }
 


### PR DESCRIPTION
## Summary

- `useNowPlaying` is consumed by both `Footer.vue` and `now.vue`, each mounting their own `setInterval` that added 1000ms to the same `useState` — causing 2s/tick progress jumps
- Every 5s API poll reset `progressMs` to the Spotify value, creating visible rewinds
- Elevates intervals to module-level singletons guarded by `_activeConsumers` counter

## Root Cause

```
Footer.vue mounts → setInterval adds 1000ms/s
now.vue mounts    → another setInterval adds 1000ms/s
               ↓
  shared useState += 2000ms per tick (user sees 2s jumps)
  every 5s fetch resets to real value (user sees rewind)
```

## Fix

Module-level `_fetchInterval`, `_progressInterval`, and `_activeConsumers` ensure a single pair of intervals runs regardless of how many components call the composable.

## Test Plan
- [ ] Open `/now` page with a song playing — progress bar should advance 1s/tick smoothly
- [ ] Footer "NOW PLAYING" indicator should animate without jumps
- [ ] Navigating away and back should not create new duplicate intervals