### PR TITLE
🚀 Release 1.10.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.10.12] - 2026-05-21
+
+### Fixed
+- **`useNowPlaying` duplicate intervals** — Composable was instantiated in both `Footer.vue` and `now.vue`, creating two independent `setInterval` callbacks that each added 1000ms to the same shared `useState`. Result: 2s/tick progress jumps and periodic rewinds on every Spotify API poll. Intervals are now module-level singletons guarded by an `_activeConsumers` counter. (#110)
+
+---
+
+## [1.10.11] - 2026-05-21
+
+### Changed
+- Bump nightwire submodule to v2-alpha (530c4a8) — adds v2 semantic tokens,
+  intensity system, and new components while keeping all v1 classes intact.
+
+---
+
 ## [1.10.10] - 2026-05-15
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-app",
-  "version": "1.10.10",
+  "version": "1.10.12",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/composables/useNowPlaying.ts
+++ b/src/composables/useNowPlaying.ts
@@ -11,43 +11,45 @@ interface NowPlayingData {
   durationMs?: number
 }
 
+// Singletons so multiple components sharing this composable don't create duplicate intervals
+let _fetchInterval: ReturnType<typeof setInterval> | null = null
+let _progressInterval: ReturnType<typeof setInterval> | null = null
+let _activeConsumers = 0
+
 export function useNowPlaying() {
   const data = useState<NowPlayingData>('now-playing', () => ({ isPlaying: false }))
-  let lastFetchTime = 0
 
   async function fetchNowPlaying() {
     try {
       const result = await $fetch<NowPlayingData>('/api/spotify/now-playing')
       data.value = result
-      lastFetchTime = Date.now()
     } catch {
       data.value = { isPlaying: false }
     }
   }
 
   if (import.meta.client) {
-    let fetchInterval: ReturnType<typeof setInterval> | null = null
-    let progressInterval: ReturnType<typeof setInterval> | null = null
-
     onMounted(() => {
-      fetchNowPlaying()
-      fetchInterval = setInterval(fetchNowPlaying, 5_000)
+      _activeConsumers++
+      if (_activeConsumers === 1) {
+        fetchNowPlaying()
+        _fetchInterval = setInterval(fetchNowPlaying, 5_000)
 
-      // Interpolate progress smoothly between 5s polls
-      progressInterval = setInterval(() => {
-        if (data.value.isPlaying && data.value.progressMs !== undefined && data.value.durationMs !== undefined) {
-          const elapsed = Date.now() - lastFetchTime
-          // Add elapsed time to the base progress we got from the API, capping at duration
-          data.value.progressMs = Math.min(data.value.progressMs + 1000, data.value.durationMs)
-          // Update lastFetchTime so we only add 1s next tick
-          lastFetchTime = Date.now()
-        }
-      }, 1000)
+        // Interpolate progress between API polls (runs once, shared across all consumers)
+        _progressInterval = setInterval(() => {
+          if (data.value.isPlaying && data.value.progressMs !== undefined && data.value.durationMs !== undefined) {
+            data.value.progressMs = Math.min(data.value.progressMs + 1000, data.value.durationMs)
+          }
+        }, 1000)
+      }
     })
 
     onUnmounted(() => {
-      if (fetchInterval) clearInterval(fetchInterval)
-      if (progressInterval) clearInterval(progressInterval)
+      _activeConsumers--
+      if (_activeConsumers === 0) {
+        if (_fetchInterval) { clearInterval(_fetchInterval); _fetchInterval = null }
+        if (_progressInterval) { clearInterval(_progressInterval); _progressInterval = null }
+      }
     })
   }
 


### PR DESCRIPTION
## Release v1.10.12

### Fixed
- **`useNowPlaying` duplicate intervals** (#110) — Now-playing progress was jumping 2s/tick and rewinding periodically because both `Footer.vue` and `now.vue` each created their own `setInterval` on the shared composable state. Intervals are now module-level singletons.

---

Merging this PR will trigger the auto-release workflow → GitHub Release → deploy to production.