### PR TITLE
feat(admin): Nightwire redesign — remove blog, sidebar, dashboard, tables, login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ coverage-*.json
 
 # Claude Code — ephemeral worktrees (keep agents/commands/skills tracked)
 .claude/worktrees/
+
+# Superpowers brainstorm sessions
+.superpowers/

--- a/docs/superpowers/plans/2026-05-24-admin-redesign.md
+++ b/docs/superpowers/plans/2026-05-24-admin-redesign.md
@@ -1,0 +1,917 @@
+# Admin Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the blog section from the admin nav and restyle the entire admin UI (sidebar, dashboard, tables, login) to fully leverage the Nightwire design system.
+
+**Architecture:** All changes are purely in Vue templates and Tailwind classes. No new components are created — existing pages are restyled in-place. The Nightwire panel/metric-cell/table patterns are applied consistently across all admin pages.
+
+**Tech Stack:** Nuxt 3, Vue 3, Tailwind CSS, Nightwire design system (`.nightwire/nightwire.css` + `tailwind.preset.js`), Lucide icons (auto-imported)
+
+---
+
+### Task 1: Remove Blog from Admin Layout + Sidebar Redesign
+
+**Files:**
+- Modify: `src/layouts/admin.vue`
+
+- [ ] **Step 1: Remove blog from navItems**
+
+In `src/layouts/admin.vue`, replace the `navItems` ref so the blog entry is gone and the section label is added:
+
+```ts
+const navItems = ref([
+  { path: '/admin', label: 'Dashboard', icon: 'LucideLayoutDashboard' },
+  {
+    path: '/admin/projects',
+    label: 'Projects',
+    icon: 'LucideFolderOpen',
+    children: [
+      { path: '/admin/projects', label: 'All Projects', icon: 'LucideList' },
+      { path: '/admin/projects/new', label: 'New Project', icon: 'LucidePlus' },
+    ],
+  },
+  {
+    path: '/admin/users',
+    label: 'Users',
+    icon: 'LucideUsers',
+    children: [
+      { path: '/admin/users', label: 'All Users', icon: 'LucideList' },
+    ],
+  },
+  {
+    path: '/admin/contacts',
+    label: 'Contacts',
+    icon: 'LucideMail',
+    children: [
+      { path: '/admin/contacts', label: 'All Contacts', icon: 'LucideList' },
+    ],
+  },
+])
+```
+
+- [ ] **Step 2: Remove blog branches from currentPageTitle**
+
+Replace the full `currentPageTitle` computed:
+
+```ts
+const currentPageTitle = computed(() => {
+  const path = route.path
+  if (path === '/admin' || path === '/admin/') return 'Dashboard'
+  if (path.startsWith('/admin/projects/new')) return 'Projects / New Project'
+  if (path.startsWith('/admin/projects/')) return 'Projects / Edit Project'
+  if (path === '/admin/projects') return 'Projects'
+  if (path === '/admin/users') return 'Users'
+  if (path === '/admin/contacts') return 'Contacts'
+  return 'Admin'
+})
+```
+
+- [ ] **Step 3: Restyle the sidebar template**
+
+Replace the entire `<aside>` block (lines 4–61) with:
+
+```html
+<!-- Sidebar -->
+<aside class="w-60 bg-void-warm border-r border-nw-text-line flex flex-col shrink-0">
+  <!-- Logo -->
+  <div class="h-10 flex items-center px-4 border-b border-nw-primary-dim shrink-0">
+    <NuxtLink to="/admin" class="font-stamp text-[15px] tracking-[0.12em]">
+      <span class="text-nw-primary">{</span>
+      <span class="text-nw-red">Admin</span>
+      <span class="text-nw-primary">}</span>
+    </NuxtLink>
+  </div>
+
+  <!-- Nav -->
+  <nav class="flex-1 py-2 overflow-y-auto">
+    <div class="font-stamp text-[8px] tracking-[0.18em] uppercase text-nw-primary-dim px-4 pt-3 pb-1">
+      Navigation
+    </div>
+
+    <template v-for="item in navItems" :key="item.path">
+      <NuxtLink
+        :to="item.path"
+        class="flex items-center gap-2.5 pl-4 pr-3 py-[6px] text-[11px] border-l-2 transition-colors cursor-pointer"
+        :class="getNavClass(item.path)"
+      >
+        <span class="w-[5px] h-[5px] rounded-full shrink-0 transition-all" :class="isActiveRoute(item.path) ? 'bg-nw-cyan shadow-[0_0_5px_theme(colors.nw.cyan.DEFAULT)]' : 'bg-nw-text-dim'" />
+        <span>{{ item.label }}</span>
+      </NuxtLink>
+
+      <div v-if="item.children" class="ml-4 mt-0.5">
+        <NuxtLink
+          v-for="child in item.children"
+          :key="child.path"
+          :to="child.path"
+          class="flex items-center gap-2 pl-7 pr-3 py-[5px] text-[10px] border-l-2 transition-colors cursor-pointer"
+          :class="getNavChildClass(child.path)"
+        >
+          <span class="w-[3px] h-[3px] rounded-full shrink-0" :class="isExactRoute(child.path) ? 'bg-nw-cyan' : 'bg-nw-text-dim/50'" />
+          {{ child.label }}
+        </NuxtLink>
+      </div>
+    </template>
+  </nav>
+
+  <!-- User section -->
+  <div class="p-3 border-t border-nw-text-line shrink-0">
+    <div class="flex items-center gap-2 mb-2 px-1">
+      <div class="w-6 h-6 rounded-full bg-void-raised border border-nw-primary-dim flex items-center justify-center text-[10px] font-bold text-nw-cyan shrink-0">
+        {{ userInitial }}
+      </div>
+      <p class="text-[9px] text-nw-text-dim truncate">{{ authUser?.email || 'Admin' }}</p>
+    </div>
+    <button
+      @click="logout"
+      class="flex items-center gap-2 w-full px-2 py-1 text-[10px] font-stamp tracking-[0.1em] uppercase text-nw-red/70 hover:text-nw-red hover:bg-nw-red/[0.06] transition-colors"
+    >
+      <LucideLogOut class="w-3 h-3" />
+      Logout
+    </button>
+  </div>
+</aside>
+```
+
+- [ ] **Step 4: Update getNavClass and getNavChildClass**
+
+Replace both functions:
+
+```ts
+function getNavClass(path: string): string {
+  if (path === '/admin') {
+    return isExactRoute(path)
+      ? 'border-l-nw-cyan bg-nw-cyan/[0.06] text-nw-cyan'
+      : 'border-l-transparent text-nw-text-dim hover:text-nw-text hover:bg-void-raised/20'
+  }
+  return isActiveRoute(path)
+    ? 'border-l-nw-cyan bg-nw-cyan/[0.06] text-nw-cyan'
+    : 'border-l-transparent text-nw-text-dim hover:text-nw-text hover:bg-void-raised/20'
+}
+
+function getNavChildClass(path: string): string {
+  return isExactRoute(path)
+    ? 'border-l-nw-cyan bg-nw-cyan/[0.04] text-nw-cyan'
+    : 'border-l-transparent text-nw-text-dim hover:text-nw-text hover:bg-void-raised/10'
+}
+```
+
+- [ ] **Step 5: Update top bar template**
+
+Replace the `<header>` block:
+
+```html
+<!-- Top Bar -->
+<header class="h-10 border-b border-nw-text-line bg-void-warm px-5 flex items-center justify-between shrink-0">
+  <div class="flex items-center gap-2">
+    <span class="text-nw-text-line text-[10px]">›</span>
+    <span class="font-stamp text-[11px] tracking-[0.1em] uppercase text-nw-text-dim">{{ currentPageTitle }}</span>
+  </div>
+  <NuxtLink to="/" target="_blank" class="font-stamp text-[9px] tracking-[0.12em] uppercase text-nw-primary-dim hover:text-nw-primary transition-colors flex items-center gap-1">
+    <LucideExternalLink class="w-3 h-3" />
+    View site
+  </NuxtLink>
+</header>
+```
+
+- [ ] **Step 6: Start dev server and verify sidebar**
+
+```bash
+yarn dev
+```
+
+Open http://localhost:3000/admin. Verify:
+- Blog Posts is gone from the nav
+- Active items have a left cyan border + nav dot glowing
+- Logo uses `{Admin}` in stamp font with primary-dim bottom border
+- User section shows avatar initial + logout button
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/layouts/admin.vue
+git commit -m "🔥 feat(admin): remove blog nav + Nightwire sidebar redesign"
+```
+
+---
+
+### Task 2: Dashboard Redesign
+
+**Files:**
+- Modify: `src/pages/admin/index.vue`
+
+- [ ] **Step 1: Replace the template**
+
+Replace the entire `<template>` block with:
+
+```html
+<template>
+  <div class="flex flex-col gap-4">
+    <div class="font-stamp text-[13px] tracking-[0.14em] uppercase text-nw-text">Dashboard</div>
+
+    <!-- Metrics strip -->
+    <div class="grid grid-cols-4 gap-px bg-nw-text-faint border border-nw-text-faint">
+      <div class="bg-void-warm px-4 py-3">
+        <div class="font-stamp text-[9px] tracking-[0.14em] uppercase text-nw-primary mb-1">Projects</div>
+        <div class="text-[24px] font-bold text-nw-green leading-none" style="text-shadow: 0 0 8px rgba(122,237,122,0.35);">{{ projectCount }}</div>
+        <div class="font-stamp text-[8px] text-nw-text-dim mt-1">total</div>
+      </div>
+      <div class="bg-void-warm px-4 py-3">
+        <div class="font-stamp text-[9px] tracking-[0.14em] uppercase text-nw-primary mb-1">Unread</div>
+        <div class="text-[24px] font-bold text-nw-yellow leading-none" style="text-shadow: 0 0 8px rgba(232,153,58,0.35);">{{ unreadContacts }}</div>
+        <div class="font-stamp text-[8px] text-nw-text-dim mt-1">contacts</div>
+      </div>
+      <div class="bg-void-warm px-4 py-3">
+        <div class="font-stamp text-[9px] tracking-[0.14em] uppercase text-nw-primary mb-1">Users</div>
+        <div class="text-[24px] font-bold text-nw-cyan leading-none" style="text-shadow: 0 0 8px rgba(102,221,255,0.3);">{{ userCount }}</div>
+        <div class="font-stamp text-[8px] text-nw-text-dim mt-1">admins</div>
+      </div>
+      <div class="bg-void-warm px-4 py-3">
+        <div class="font-stamp text-[9px] tracking-[0.14em] uppercase text-nw-primary mb-2">System</div>
+        <div class="flex items-center gap-2">
+          <span class="led green blink" />
+          <span class="font-stamp text-[11px] text-nw-green">NOMINAL</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Panel pair -->
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <!-- Recent Projects -->
+      <div class="bg-void-warm border border-nw-text-faint">
+        <div class="flex justify-between items-center px-3 py-[7px] border-b border-nw-primary-dim">
+          <span class="font-stamp text-[9px] tracking-[0.14em] uppercase text-nw-primary">Recent Projects</span>
+          <span class="font-stamp text-[8px] text-nw-text-dim">CASE FILES</span>
+        </div>
+        <div>
+          <NuxtLink
+            v-for="project in recentProjects"
+            :key="project.id"
+            :to="`/admin/projects/${project.id}`"
+            class="flex items-center justify-between px-3 py-[7px] border-b border-nw-text-faint last:border-b-0 hover:bg-nw-cyan/[0.04] transition-colors"
+          >
+            <span class="text-[11px] text-nw-text-dim">{{ project.title }}</span>
+            <span class="font-stamp text-[8px] border px-1.5 py-px" :class="projectBadgeClass(project)">
+              {{ project.status || (project.isFeatured ? 'FEATURED' : 'STD') }}
+            </span>
+          </NuxtLink>
+          <div v-if="!recentProjects.length" class="px-3 py-4 text-[10px] text-nw-text-dim font-stamp">
+            No projects yet
+          </div>
+        </div>
+      </div>
+
+      <!-- Recent Contacts -->
+      <div class="bg-void-warm border border-nw-text-faint">
+        <div class="flex justify-between items-center px-3 py-[7px] border-b border-nw-primary-dim">
+          <span class="font-stamp text-[9px] tracking-[0.14em] uppercase text-nw-primary">Contacts</span>
+          <span class="font-stamp text-[8px] text-nw-text-dim">INBOX</span>
+        </div>
+        <div>
+          <NuxtLink
+            v-for="contact in recentContacts"
+            :key="contact.id"
+            to="/admin/contacts"
+            class="flex items-center justify-between px-3 py-[7px] border-b border-nw-text-faint last:border-b-0 hover:bg-nw-cyan/[0.04] transition-colors"
+          >
+            <span class="text-[11px] text-nw-text-dim truncate max-w-[160px]">{{ contact.name }}</span>
+            <span class="font-stamp text-[8px] border px-1.5 py-px" :class="contact.isRead ? 'text-[#555] border-[#333]' : 'text-nw-yellow border-nw-yellow/40 bg-nw-yellow/[0.06]'">
+              {{ contact.isRead ? 'READ' : 'UNREAD' }}
+            </span>
+          </NuxtLink>
+          <div v-if="!recentContacts.length" class="px-3 py-4 text-[10px] text-nw-text-dim font-stamp">
+            No contacts yet
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+```
+
+- [ ] **Step 2: Replace the script**
+
+Replace the entire `<script setup lang="ts">` block with:
+
+```ts
+<script setup lang="ts">
+definePageMeta({
+  layout: 'admin',
+  middleware: ['admin-auth'],
+})
+
+interface DashProject { id: number; title: string; isFeatured?: boolean; status?: string }
+interface DashContact { id: number; name: string; isRead: boolean }
+
+const projectCount = ref(0)
+const unreadContacts = ref(0)
+const userCount = ref(0)
+const recentProjects = ref<DashProject[]>([])
+const recentContacts = ref<DashContact[]>([])
+
+function projectBadgeClass(p: DashProject) {
+  const s = (p.status || '').toLowerCase()
+  if (['live', 'completed', 'production'].includes(s))
+    return 'text-nw-green border-nw-green-dim bg-nw-green-faint'
+  if (['wip', 'active', 'in-progress'].includes(s))
+    return 'text-nw-yellow border-nw-yellow/40 bg-nw-yellow/[0.06]'
+  return 'text-nw-text-dim border-nw-text-line'
+}
+
+onMounted(async () => {
+  try {
+    const [projects, contacts, users] = await Promise.all([
+      $fetch<Record<string, unknown>>('/api/projects').catch(() => ({ data: [] })),
+      $fetch<Record<string, unknown>>('/api/admin/contacts').catch(() => ({ data: [] })),
+      $fetch<Record<string, unknown>>('/api/admin/users').catch(() => ({ data: [] })),
+    ])
+
+    const projArray = (projects.data as DashProject[]) || []
+    const contactArray = (contacts.data as DashContact[]) || []
+    const userArray = (users.data as unknown[]) || []
+
+    projectCount.value = projArray.length
+    unreadContacts.value = contactArray.filter(c => !c.isRead).length
+    userCount.value = userArray.length
+    recentProjects.value = projArray.slice(0, 3)
+    recentContacts.value = contactArray.slice(0, 3)
+  } catch { /* ignore */ }
+})
+</script>
+```
+
+- [ ] **Step 3: Verify in browser**
+
+With `yarn dev` running, open http://localhost:3000/admin. Verify:
+- 4 metric cells render in a strip (Projects / Unread / Users / System)
+- System cell shows green LED + NOMINAL
+- Recent Projects and Contacts panels show data rows
+- Numbers update after data loads (may be 0 if API requires auth)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/admin/index.vue
+git commit -m "✨ feat(admin): dashboard metrics-strip + data panels"
+```
+
+---
+
+### Task 3: Projects List — nw-table
+
+**Files:**
+- Modify: `src/pages/admin/projects/index.vue`
+
+- [ ] **Step 1: Replace the template**
+
+Replace the entire `<template>` block:
+
+```html
+<template>
+  <div class="flex flex-col gap-4">
+    <!-- Header row -->
+    <div class="flex justify-between items-center">
+      <span class="font-stamp text-[13px] tracking-[0.14em] uppercase text-nw-text">Projects</span>
+      <NuxtLink
+        to="/admin/projects/new"
+        class="btn flex items-center gap-1.5 text-[11px]"
+      >
+        <LucidePlus class="w-3.5 h-3.5" />
+        New Project
+      </NuxtLink>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="py-12 text-center font-stamp text-[10px] tracking-wider uppercase text-nw-text-dim">
+      Loading…
+    </div>
+
+    <!-- Table -->
+    <div v-else-if="projects.length" class="bg-void-warm border border-nw-text-faint">
+      <div class="flex justify-between items-center px-3 py-[7px] border-b border-nw-primary-dim">
+        <span class="font-stamp text-[9px] tracking-[0.14em] uppercase text-nw-primary">All Projects</span>
+        <span class="font-stamp text-[8px] text-nw-text-dim">{{ projects.length }} RECORDS</span>
+      </div>
+      <table class="w-full">
+        <thead>
+          <tr>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-left px-3 py-[6px] border-b border-nw-primary-dim">Title</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-left px-3 py-[6px] border-b border-nw-primary-dim hidden md:table-cell">Status</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-left px-3 py-[6px] border-b border-nw-primary-dim hidden lg:table-cell">Stack</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-right px-3 py-[6px] border-b border-nw-primary-dim">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="project in projects"
+            :key="project.id"
+            class="border-b border-nw-text-faint last:border-b-0 hover:bg-nw-cyan/[0.04] transition-colors"
+          >
+            <td class="px-3 py-[7px]">
+              <p class="text-[11px] text-nw-text">{{ project.title }}</p>
+              <p class="text-[10px] text-nw-text-dim truncate max-w-xs">{{ project.shortDescription || project.description }}</p>
+            </td>
+            <td class="px-3 py-[7px] hidden md:table-cell">
+              <span
+                class="font-stamp text-[8px] tracking-[0.1em] uppercase border px-1.5 py-px"
+                :class="project.isFeatured ? 'text-nw-purple border-nw-purple/40 bg-nw-purple/[0.06]' : 'text-nw-text-dim border-nw-text-line'"
+              >
+                {{ project.isFeatured ? 'FEATURED' : 'STD' }}
+              </span>
+            </td>
+            <td class="px-3 py-[7px] hidden lg:table-cell">
+              <div class="flex flex-wrap gap-1">
+                <span v-for="tech in (project.techStack || []).slice(0, 3)" :key="tech" class="font-stamp text-[8px] text-nw-cyan">
+                  {{ tech }}
+                </span>
+                <span v-if="(project.techStack || []).length > 3" class="font-stamp text-[8px] text-nw-text-dim">
+                  +{{ (project.techStack || []).length - 3 }}
+                </span>
+              </div>
+            </td>
+            <td class="px-3 py-[7px] text-right">
+              <NuxtLink
+                :to="`/admin/projects/${project.id}`"
+                class="font-stamp text-[9px] tracking-[0.1em] uppercase text-nw-primary-dim hover:text-nw-primary transition-colors"
+              >
+                EDIT
+              </NuxtLink>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Empty -->
+    <div v-else class="py-12 text-center font-stamp text-[10px] tracking-wider uppercase text-nw-text-dim">
+      No projects found.
+    </div>
+  </div>
+</template>
+```
+
+Keep the `<script setup>` block unchanged.
+
+- [ ] **Step 2: Verify in browser**
+
+Open http://localhost:3000/admin/projects. Verify:
+- Panel header shows "All Projects" + record count
+- Table headers in nw-primary blue stamp font
+- Row hover turns slightly cyan
+- "New Project" button uses `btn` class (nw-primary fill)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/admin/projects/index.vue
+git commit -m "✨ feat(admin): projects list nw-table pattern"
+```
+
+---
+
+### Task 4: Contacts List — nw-table
+
+**Files:**
+- Modify: `src/pages/admin/contacts/index.vue`
+
+- [ ] **Step 1: Replace the template**
+
+Replace only the `<template>` block (keep `<script setup>` unchanged):
+
+```html
+<template>
+  <div class="flex flex-col gap-4">
+    <span class="font-stamp text-[13px] tracking-[0.14em] uppercase text-nw-text">Contacts</span>
+
+    <!-- Loading -->
+    <div v-if="loading" class="py-12 text-center font-stamp text-[10px] tracking-wider uppercase text-nw-text-dim">
+      Loading…
+    </div>
+
+    <!-- Table -->
+    <div v-else-if="contacts.length" class="bg-void-warm border border-nw-text-faint">
+      <div class="flex justify-between items-center px-3 py-[7px] border-b border-nw-primary-dim">
+        <span class="font-stamp text-[9px] tracking-[0.14em] uppercase text-nw-primary">All Contacts</span>
+        <span class="font-stamp text-[8px] text-nw-text-dim">{{ contacts.length }} RECORDS</span>
+      </div>
+      <table class="w-full">
+        <thead>
+          <tr>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-left px-3 py-[6px] border-b border-nw-primary-dim">Name</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-left px-3 py-[6px] border-b border-nw-primary-dim hidden md:table-cell">Email</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-left px-3 py-[6px] border-b border-nw-primary-dim hidden lg:table-cell">Message</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-left px-3 py-[6px] border-b border-nw-primary-dim hidden md:table-cell">Date</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-center px-3 py-[6px] border-b border-nw-primary-dim">Status</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-right px-3 py-[6px] border-b border-nw-primary-dim">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="contact in contacts"
+            :key="contact.id"
+            class="border-b border-nw-text-faint last:border-b-0 hover:bg-nw-cyan/[0.04] transition-colors"
+            :class="!contact.isRead ? 'bg-nw-primary/[0.03]' : ''"
+          >
+            <td class="px-3 py-[7px]">
+              <span class="text-[11px] text-nw-text">{{ contact.name }}</span>
+            </td>
+            <td class="px-3 py-[7px] hidden md:table-cell">
+              <a :href="`mailto:${contact.email}`" class="text-[10px] text-nw-primary hover:text-nw-primary-hot transition-colors">{{ contact.email }}</a>
+            </td>
+            <td class="px-3 py-[7px] hidden lg:table-cell">
+              <span class="text-[10px] text-nw-text-dim line-clamp-1">{{ contact.message }}</span>
+            </td>
+            <td class="px-3 py-[7px] hidden md:table-cell">
+              <span class="text-[10px] text-nw-text-dim">{{ formatDate(contact.createdAt) }}</span>
+            </td>
+            <td class="px-3 py-[7px] text-center">
+              <span
+                class="font-stamp text-[8px] tracking-[0.1em] uppercase border px-1.5 py-px"
+                :class="contact.isRead ? 'text-[#555] border-[#333]' : 'text-nw-yellow border-nw-yellow/40 bg-nw-yellow/[0.06]'"
+              >
+                {{ contact.isRead ? 'READ' : 'UNREAD' }}
+              </span>
+            </td>
+            <td class="px-3 py-[7px] text-right">
+              <button @click="viewContact(contact)" class="font-stamp text-[9px] tracking-[0.1em] uppercase text-nw-primary-dim hover:text-nw-primary transition-colors mr-3">
+                VIEW
+              </button>
+              <button @click="deleteContact(contact.id)" class="font-stamp text-[9px] tracking-[0.1em] uppercase text-nw-red/50 hover:text-nw-red transition-colors">
+                DEL
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Empty -->
+    <div v-else class="py-12 text-center font-stamp text-[10px] tracking-wider uppercase text-nw-text-dim">
+      No contacts found.
+    </div>
+
+    <!-- Contact Detail Modal — keep unchanged -->
+    <div v-if="selectedContact" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" @click.self="selectedContact = null">
+      <div class="bg-void-warm border border-nw-text-line/30 rounded-lg max-w-lg w-full p-6 max-h-[80vh] overflow-auto">
+        <div class="flex justify-between items-start mb-4">
+          <h2 class="text-lg font-bold text-nw-text">{{ selectedContact.name }}</h2>
+          <button @click="selectedContact = null" class="text-nw-text-dim hover:text-nw-text">
+            <LucideX class="w-4 h-4" />
+          </button>
+        </div>
+        <div class="space-y-3 text-sm">
+          <div>
+            <span class="text-nw-text-dim font-sys text-xs">EMAIL</span>
+            <p><a :href="`mailto:${selectedContact.email}`" class="text-nw-primary hover:underline">{{ selectedContact.email }}</a></p>
+          </div>
+          <div v-if="selectedContact.subject">
+            <span class="text-nw-text-dim font-sys text-xs">SUBJECT</span>
+            <p>{{ selectedContact.subject }}</p>
+          </div>
+          <div>
+            <span class="text-nw-text-dim font-sys text-xs">MESSAGE</span>
+            <p class="text-nw-text mt-1 whitespace-pre-wrap">{{ selectedContact.message }}</p>
+          </div>
+          <div>
+            <span class="text-nw-text-dim font-sys text-xs">DATE</span>
+            <p>{{ formatDate(selectedContact.createdAt) }}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+```
+
+- [ ] **Step 2: Verify in browser**
+
+Open http://localhost:3000/admin/contacts. Verify:
+- Unread rows have a subtle primary tint on the row background
+- UNREAD badge is yellow, READ badge is dark/muted
+- VIEW / DEL links in stamp uppercase
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/admin/contacts/index.vue
+git commit -m "✨ feat(admin): contacts list nw-table pattern"
+```
+
+---
+
+### Task 5: Users List — nw-table
+
+**Files:**
+- Modify: `src/pages/admin/users/index.vue`
+
+- [ ] **Step 1: Replace only the outer list table in the template**
+
+Replace from the opening `<div>` through the empty state (keep the modals untouched). The new template wrapper and table:
+
+```html
+<template>
+  <div class="flex flex-col gap-4">
+    <!-- Header row -->
+    <div class="flex justify-between items-center">
+      <span class="font-stamp text-[13px] tracking-[0.14em] uppercase text-nw-text">Users</span>
+      <button
+        @click="openCreateModal"
+        class="btn flex items-center gap-1.5 text-[11px]"
+      >
+        <LucidePlus class="w-3.5 h-3.5" />
+        New User
+      </button>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="py-12 text-center font-stamp text-[10px] tracking-wider uppercase text-nw-text-dim">Loading…</div>
+
+    <!-- Error -->
+    <div v-else-if="error" class="py-12 text-center font-stamp text-[10px] tracking-wider uppercase text-nw-red">{{ error }}</div>
+
+    <!-- Table -->
+    <div v-else-if="users.length" class="bg-void-warm border border-nw-text-faint">
+      <div class="flex justify-between items-center px-3 py-[7px] border-b border-nw-primary-dim">
+        <span class="font-stamp text-[9px] tracking-[0.14em] uppercase text-nw-primary">All Users</span>
+        <span class="font-stamp text-[8px] text-nw-text-dim">{{ users.length }} RECORDS</span>
+      </div>
+      <table class="w-full">
+        <thead>
+          <tr>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-left px-3 py-[6px] border-b border-nw-primary-dim">Username</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-left px-3 py-[6px] border-b border-nw-primary-dim hidden md:table-cell">Email</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-left px-3 py-[6px] border-b border-nw-primary-dim hidden lg:table-cell">Role</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-left px-3 py-[6px] border-b border-nw-primary-dim hidden md:table-cell">Created</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-right px-3 py-[6px] border-b border-nw-primary-dim">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="user in users"
+            :key="user.id"
+            class="border-b border-nw-text-faint last:border-b-0 hover:bg-nw-cyan/[0.04] transition-colors"
+          >
+            <td class="px-3 py-[7px]">
+              <span class="text-[11px] text-nw-text">{{ user.username }}</span>
+            </td>
+            <td class="px-3 py-[7px] hidden md:table-cell">
+              <span class="text-[10px] text-nw-text-dim">{{ user.email }}</span>
+            </td>
+            <td class="px-3 py-[7px] hidden lg:table-cell">
+              <span class="font-stamp text-[8px] tracking-[0.1em] uppercase border px-1.5 py-px text-nw-cyan border-nw-cyan/30 bg-nw-cyan/[0.06]">
+                {{ user.role || 'admin' }}
+              </span>
+            </td>
+            <td class="px-3 py-[7px] hidden md:table-cell">
+              <span class="text-[10px] text-nw-text-dim">{{ formatDate(user.createdAt || user.created_at) }}</span>
+            </td>
+            <td class="px-3 py-[7px] text-right">
+              <button @click="openEditModal(user)" class="font-stamp text-[9px] tracking-[0.1em] uppercase text-nw-primary-dim hover:text-nw-primary transition-colors mr-3">
+                EDIT
+              </button>
+              <button @click="openDeleteModal(user)" class="font-stamp text-[9px] tracking-[0.1em] uppercase text-nw-red/50 hover:text-nw-red transition-colors">
+                DEL
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Empty -->
+    <div v-else class="py-12 text-center font-stamp text-[10px] tracking-wider uppercase text-nw-text-dim">No users found.</div>
+
+    <!-- Modals — keep unchanged from original -->
+    <div v-if="modalUser !== undefined" class="fixed inset-0 z-50 flex items-center justify-center bg-black/60" @click.self="closeModal">
+      <div class="bg-void-warm border border-nw-text-line/30 rounded-lg p-6 max-w-sm w-full mx-4">
+        <h3 class="text-lg font-bold text-nw-text mb-4">
+          {{ modalUser === null ? 'New User' : 'Edit User' }}
+        </h3>
+        <form @submit.prevent="saveUser" class="space-y-4">
+          <div>
+            <label class="block text-sm text-nw-cyan font-sys mb-1">Username</label>
+            <input v-model="form.username" type="text" required :disabled="modalUser !== null" class="w-full px-3 py-2 bg-void-warm text-nw-text border border-nw-text-line rounded focus:outline-none focus:ring-2 focus:ring-nw-cyan font-sys text-sm disabled:opacity-50" :placeholder="modalUser === null ? 'username' : ''" />
+          </div>
+          <div>
+            <label class="block text-sm text-nw-cyan font-sys mb-1">Email</label>
+            <input v-model="form.email" type="email" required class="w-full px-3 py-2 bg-void-warm text-nw-text border border-nw-text-line rounded focus:outline-none focus:ring-2 focus:ring-nw-cyan font-sys text-sm" placeholder="user@example.com" />
+          </div>
+          <div>
+            <label class="block text-sm text-nw-cyan font-sys mb-1">{{ modalUser === null ? 'Password' : 'New Password (leave blank to keep)' }}</label>
+            <input v-model="form.password" type="password" :required="modalUser === null" class="w-full px-3 py-2 bg-void-warm text-nw-text border border-nw-text-line rounded focus:outline-none focus:ring-2 focus:ring-nw-cyan font-sys text-sm" :placeholder="modalUser === null ? 'min 6 chars' : ''" />
+          </div>
+          <p v-if="formError" class="text-red-400 text-sm font-sys" role="alert">{{ formError }}</p>
+          <p v-if="formSuccess" class="text-nw-green text-sm font-sys">{{ formSuccess }}</p>
+          <div class="flex justify-end gap-3">
+            <button type="button" @click="closeModal" class="px-4 py-2 text-sm text-nw-text-dim hover:text-nw-text transition font-sys">Cancel</button>
+            <button type="submit" :disabled="saving" class="btn text-sm disabled:opacity-50">{{ saving ? 'Saving...' : 'Save' }}</button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <div v-if="deletingUser" class="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div class="bg-void-warm border border-nw-text-line/30 rounded-lg p-6 max-w-sm w-full mx-4">
+        <h3 class="text-lg font-bold text-nw-text mb-2">Delete User</h3>
+        <p class="text-sm text-nw-text-dim mb-6">Are you sure you want to delete "<strong class="text-nw-text">{{ deletingUser.username }}</strong>"? This cannot be undone.</p>
+        <div class="flex justify-end gap-3">
+          <button @click="deletingUser = null" class="px-4 py-2 text-sm text-nw-text-dim hover:text-nw-text transition font-sys">Cancel</button>
+          <button @click="confirmDelete" class="btn-danger text-sm">Delete</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+```
+
+Keep the `<script setup>` block unchanged.
+
+- [ ] **Step 2: Verify in browser**
+
+Open http://localhost:3000/admin/users. Verify:
+- Role badge shows cyan `ADMIN` tag
+- EDIT / DEL links in stamp uppercase
+- Delete confirmation modal button now uses `btn-danger` (Nightwire red button)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/admin/users/index.vue
+git commit -m "✨ feat(admin): users list nw-table pattern"
+```
+
+---
+
+### Task 6: Admin Login Redesign + Password Eye Toggle
+
+**Files:**
+- Modify: `src/pages/admin/login.vue`
+
+- [ ] **Step 1: Replace the template**
+
+```html
+<template>
+  <div class="flex items-center justify-center min-h-screen bg-void">
+    <div class="w-full max-w-sm">
+      <!-- Logo -->
+      <div class="border border-nw-primary-dim mb-0">
+        <div class="px-5 py-4 border-b border-nw-primary-dim text-center">
+          <div class="font-stamp text-[18px] tracking-[0.12em]">
+            <span class="text-nw-primary">{</span>
+            <span class="text-nw-red">Admin</span>
+            <span class="text-nw-primary">}</span>
+          </div>
+          <p class="font-stamp text-[9px] tracking-[0.14em] uppercase text-nw-text-dim mt-1">Sign in to manage your portfolio</p>
+        </div>
+
+        <form @submit.prevent="handleLogin" class="p-5 flex flex-col gap-4">
+          <!-- Email -->
+          <div class="flex flex-col gap-1">
+            <label for="email" class="font-stamp text-[9px] tracking-[0.16em] uppercase text-nw-primary">Email</label>
+            <input
+              id="email"
+              v-model="form.email"
+              type="email"
+              required
+              autocomplete="email"
+              placeholder="you@email.com"
+              class="w-full px-3 py-2 bg-void-warm text-nw-text border border-nw-primary-dim rounded-none font-sys text-sm focus:outline-none focus:ring-1 focus:ring-nw-primary focus:border-nw-primary transition-colors"
+            >
+          </div>
+
+          <!-- Password + eye toggle -->
+          <div class="flex flex-col gap-1">
+            <label for="password" class="font-stamp text-[9px] tracking-[0.16em] uppercase text-nw-primary">Password</label>
+            <div class="relative">
+              <input
+                id="password"
+                v-model="form.password"
+                :type="showPassword ? 'text' : 'password'"
+                required
+                autocomplete="current-password"
+                placeholder="••••••••"
+                class="w-full px-3 py-2 pr-10 bg-void-warm text-nw-text border border-nw-primary-dim rounded-none font-sys text-sm focus:outline-none focus:ring-1 focus:ring-nw-primary focus:border-nw-primary transition-colors"
+              >
+              <button
+                type="button"
+                @click="showPassword = !showPassword"
+                class="absolute right-0 top-0 h-full px-3 text-nw-text-dim hover:text-nw-primary transition-colors"
+                :aria-label="showPassword ? 'Hide password' : 'Show password'"
+              >
+                <LucideEye v-if="!showPassword" class="w-4 h-4" />
+                <LucideEyeOff v-else class="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+
+          <p v-if="error" class="font-stamp text-[9px] tracking-[0.1em] uppercase text-nw-red" role="alert">{{ error }}</p>
+
+          <button
+            type="submit"
+            :disabled="loading"
+            class="btn w-full flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <LucideLoader v-if="loading" class="w-4 h-4 animate-spin" />
+            {{ loading ? 'Signing in...' : 'Sign In' }}
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+</template>
+```
+
+- [ ] **Step 2: Add showPassword ref to script**
+
+In `<script setup lang="ts">`, add after the existing refs:
+
+```ts
+const showPassword = ref(false)
+```
+
+The full script becomes:
+
+```ts
+<script setup lang="ts">
+definePageMeta({
+  layout: false,
+  middleware: ['admin-auth'],
+})
+
+const form = reactive({ email: '', password: '' })
+const loading = ref(false)
+const error = ref<string | null>(null)
+const showPassword = ref(false)
+
+async function handleLogin() {
+  loading.value = true
+  error.value = null
+
+  const success = await useAdminAuth().login(form.email, form.password)
+
+  if (success) {
+    await navigateTo('/admin')
+  } else {
+    error.value = 'Invalid credentials. Please try again.'
+  }
+
+  loading.value = false
+}
+</script>
+```
+
+- [ ] **Step 3: Verify in browser**
+
+Open http://localhost:3000/admin/login. Verify:
+- Full dark void background, centered panel
+- Inputs have `nw-primary-dim` border (visible blue-ish tint), sharp corners
+- Eye icon toggles password visibility on click
+- Focus state shows `ring-1 nw-primary` ring
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/admin/login.vue
+git commit -m "✨ feat(admin): login Nightwire redesign + password eye toggle"
+```
+
+---
+
+### Task 7: TypeScript Check + PR
+
+- [ ] **Step 1: Run type check**
+
+```bash
+npx nuxi typecheck
+```
+
+Expected: no new type errors introduced by the changes.
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create \
+  --base develop \
+  --title "feat(admin): Nightwire redesign — remove blog, sidebar, dashboard, tables, login" \
+  --body "$(cat <<'EOF'
+## Summary
+- Removes Blog Posts section from admin nav (pages never existed)
+- Restyled sidebar with Nightwire panel patterns (left-border active indicator, nav dots, section label)
+- Dashboard redesigned with 4-cell metrics strip + data panels (Recent Projects + Contacts)
+- Projects / Contacts / Users lists now use nw-table pattern (blue headers, stamp badges, cyan hover)
+- Login page redesigned with Nightwire inputs + password show/hide eye toggle
+
+## Test plan
+- [ ] Blog Posts is absent from admin sidebar
+- [ ] Sidebar active items show cyan left-border + glowing dot
+- [ ] Dashboard metrics-strip loads counts; System cell shows green LED
+- [ ] Recent Projects and Contacts panels show up to 3 rows each
+- [ ] Projects table shows blue headers, stamp badges, stamp EDIT link
+- [ ] Contacts table UNREAD rows have yellow badge; READ rows muted
+- [ ] Users table Role badge is cyan
+- [ ] Login: inputs have visible nw-primary-dim border, sharp corners
+- [ ] Login: eye icon toggles password visibility
+- [ ] TypeScript check passes
+EOF
+)"
+```

--- a/docs/superpowers/plans/2026-05-24-homepage-redesign.md
+++ b/docs/superpowers/plans/2026-05-24-homepage-redesign.md
@@ -1,0 +1,401 @@
+# Homepage Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update the favicon to a Nightwire-styled SVG, then apply focused visual improvements to the homepage (Hero, FeatureProjectCard, LatestPosts, BaseInput, BaseTextarea) to bring them fully in line with the Nightwire design system.
+
+**Architecture:** All changes are purely in Vue templates and Tailwind class lists. No new components are created. The favicon becomes an SVG with the Nightwire `C` motif on a void background. The contact form fields (BaseInput/Textarea) receive Variant A styling agreed in the design session.
+
+**Tech Stack:** Nuxt 3, Vue 3, Tailwind CSS, Nightwire design system (`.nightwire/nightwire.css` + `tailwind.preset.js`), Lucide icons (auto-imported), static SVG for favicon
+
+---
+
+### Task 0: Nightwire Favicon
+
+**Files:**
+- Create: `src/public/favicon.svg`
+- Modify: `nuxt.config.ts`
+
+- [ ] **Step 1: Create the SVG favicon**
+
+Create `src/public/favicon.svg` with this exact content (dark void background + nw-primary `C` initial + panel border):
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#000000"/>
+  <rect x="1" y="1" width="30" height="30" fill="none" stroke="#4477cc" stroke-width="1"/>
+  <path d="M22 10 Q10 10 10 16 Q10 22 22 22" stroke="#6699ff" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+</svg>
+```
+
+Design rationale: `#000000` = `--void`, `#4477cc` = `--nw-primary-dim` (panel border), `#6699ff` = `--nw-primary` (C initial). The `C` is a single arc path readable at 16×16.
+
+- [ ] **Step 2: Wire the SVG favicon in nuxt.config.ts**
+
+In `nuxt.config.ts`, find the `head.link` array (currently starts at line 62) and add the SVG favicon entry at the top of the array. Keep the existing font preconnect entries unchanged:
+
+```ts
+link: [
+  { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' },
+  { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
+  { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' },
+  {
+    rel: 'stylesheet',
+    href: 'https://fonts.googleapis.com/css2?family=Noto+Serif+Display:wght@700;800;900&family=JetBrains+Mono:wght@400;500;700&family=Saira+Extra+Condensed:wght@400;600;700;800&family=Shippori+Mincho+B1:wght@500;700;800&display=swap'
+  },
+],
+```
+
+The existing `src/public/favicon.ico` stays as a fallback for older browsers — do not remove it.
+
+- [ ] **Step 3: Run dev server and verify**
+
+```bash
+npm run dev
+```
+
+Open `http://localhost:3000` and check the browser tab — the favicon should show the dark `C` icon. Zoom the tab strip to confirm it's legible.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/public/favicon.svg nuxt.config.ts
+git commit -m "feat(favicon): add Nightwire-styled SVG favicon"
+```
+
+---
+
+### Task 1: Hero — Avatar Glow + DT Label Color
+
+**Files:**
+- Modify: `src/components/home/Hero.vue`
+
+**Current state:**
+- `NuxtImg` has `class="relative w-[180px] h-[180px] object-cover border border-nw-primary-dim"` (line 78)
+- `<dl>` children `<dt>` elements have no explicit color class — they inherit `text-nw-text-dim` from the `<dl>` (line 83)
+
+- [ ] **Step 1: Add avatar glow to NuxtImg**
+
+In `src/components/home/Hero.vue` at line 78, add the Tailwind shadow utility to the `NuxtImg` class string:
+
+Replace:
+```html
+class="relative w-[180px] h-[180px] object-cover border border-nw-primary-dim"
+```
+
+With:
+```html
+class="relative w-[180px] h-[180px] object-cover border border-nw-primary-dim shadow-[0_0_28px_rgba(102,153,255,0.18),0_0_56px_rgba(102,153,255,0.07)]"
+```
+
+- [ ] **Step 2: Update dt label color**
+
+In `src/components/home/Hero.vue`, the `<dl>` wrapper (line 83) already has `text-nw-text-dim` which is inherited by both `<dt>` and `<dd>`. The `<dd>` elements already override to `text-nw-text`. Add explicit `text-nw-primary` class to each `<dt>`:
+
+Replace the three `<div>` rows (lines 84–86):
+```html
+<div class="flex justify-between gap-2"><dt>OPERATOR</dt><dd class="text-nw-text">CATIVO-01</dd></div>
+<div class="flex justify-between gap-2"><dt>CLEARANCE</dt><dd class="text-nw-text">TECH-LEAD</dd></div>
+<div class="flex justify-between gap-2"><dt>UNIT</dt><dd class="text-nw-text">BLUE-MEDICAL-GT</dd></div>
+```
+
+With:
+```html
+<div class="flex justify-between gap-2"><dt class="text-nw-primary">OPERATOR</dt><dd class="text-nw-text">CATIVO-01</dd></div>
+<div class="flex justify-between gap-2"><dt class="text-nw-primary">CLEARANCE</dt><dd class="text-nw-text">TECH-LEAD</dd></div>
+<div class="flex justify-between gap-2"><dt class="text-nw-primary">UNIT</dt><dd class="text-nw-text">BLUE-MEDICAL-GT</dd></div>
+```
+
+- [ ] **Step 3: Run dev server and verify**
+
+```bash
+npm run dev
+```
+
+Navigate to `http://localhost:3000`. The Hero section should show:
+- Avatar image with a subtle blue outer glow
+- OPERATOR / CLEARANCE / UNIT labels in nw-primary blue (not the dim gray they were before)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/home/Hero.vue
+git commit -m "feat(hero): add avatar glow and upgrade dt label color to nw-primary"
+```
+
+---
+
+### Task 2: FeatureProjectCard — Featured Card Left Accent + Glow
+
+**Files:**
+- Modify: `src/components/home/portfolio/FeatureProjectCard.vue`
+
+**Current state (line 3–8):**
+```html
+:class="[
+  'bg-void-raised hover:bg-void-panel border hover:border-nw-primary-dim transition-all duration-200 p-5 flex flex-col gap-3',
+  featured ? 'border-nw-primary-dim/50' : 'border-nw-text-line',
+  'hover:-translate-y-0.5 hover:shadow-[0_4px_20px_rgba(102,153,255,0.08)]',
+]"
+```
+
+- [ ] **Step 1: Apply featured card border + glow classes**
+
+In `src/components/home/portfolio/FeatureProjectCard.vue`, replace the `:class` binding on the `<NuxtLink>` (lines 3–8):
+
+Replace:
+```html
+:class="[
+  'bg-void-raised hover:bg-void-panel border hover:border-nw-primary-dim transition-all duration-200 p-5 flex flex-col gap-3',
+  featured ? 'border-nw-primary-dim/50' : 'border-nw-text-line',
+  'hover:-translate-y-0.5 hover:shadow-[0_4px_20px_rgba(102,153,255,0.08)]',
+]"
+```
+
+With:
+```html
+:class="[
+  'bg-void-raised hover:bg-void-panel border transition-all duration-200 p-5 flex flex-col gap-3',
+  featured
+    ? 'border-nw-primary/40 border-l-[3px] border-l-nw-primary shadow-[inset_3px_0_16px_rgba(102,153,255,0.06),0_4px_24px_rgba(102,153,255,0.07)] hover:border-nw-primary-hot/50'
+    : 'border-nw-text-line hover:border-nw-primary-dim',
+  'hover:-translate-y-0.5',
+]"
+```
+
+Note: the base `hover:shadow-[...]` on the last line is removed — featured already has its own shadow, and normal cards don't need the lift shadow (they get the border highlight instead).
+
+- [ ] **Step 2: Run dev server and verify**
+
+```bash
+npm run dev
+```
+
+Navigate to `http://localhost:3000` and scroll to the Projects section. The featured card (the one at the top / first in the grid, where `featured=true`) should have:
+- A visible 3px nw-primary left border accent
+- A subtle inner-left blue glow
+- A brighter overall border vs. normal cards
+
+Normal (non-featured) cards should look unchanged.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/home/portfolio/FeatureProjectCard.vue
+git commit -m "feat(portfolio): add left accent + glow to featured project card"
+```
+
+---
+
+### Task 3: LatestPosts — FEED·LIVE LED Indicator
+
+**Files:**
+- Modify: `src/components/home/LatestPosts.vue`
+
+**Current state (lines 3–12):**
+```html
+<div class="panel-header">
+  <span>WRITING · LATEST</span>
+  <a
+    href="https://blog.cativo.dev"
+    target="_blank"
+    rel="noopener noreferrer"
+    class="text-nw-primary hover:text-nw-primary-hot text-[10px] font-stamp uppercase tracking-wider"
+  >
+    BLOG.CATIVO.DEV →
+  </a>
+</div>
+```
+
+- [ ] **Step 1: Add FEED·LIVE indicator to panel-header**
+
+In `src/components/home/LatestPosts.vue`, replace the `panel-header` block (lines 3–12):
+
+Replace:
+```html
+<div class="panel-header">
+  <span>WRITING · LATEST</span>
+  <a
+    href="https://blog.cativo.dev"
+    target="_blank"
+    rel="noopener noreferrer"
+    class="text-nw-primary hover:text-nw-primary-hot text-[10px] font-stamp uppercase tracking-wider"
+  >
+    BLOG.CATIVO.DEV →
+  </a>
+</div>
+```
+
+With:
+```html
+<div class="panel-header">
+  <div class="flex items-center gap-3">
+    <span>WRITING · LATEST</span>
+    <span class="flex items-center gap-1.5 text-nw-green font-stamp text-[8px] tracking-[0.12em] uppercase">
+      <span class="led green blink" />
+      FEED · LIVE
+    </span>
+  </div>
+  <a
+    href="https://blog.cativo.dev"
+    target="_blank"
+    rel="noopener noreferrer"
+    class="text-nw-primary hover:text-nw-primary-hot text-[10px] font-stamp uppercase tracking-wider"
+  >
+    BLOG.CATIVO.DEV →
+  </a>
+</div>
+```
+
+The `.led.green.blink` classes come from Nightwire CSS — they render a small pulsing green dot consistent with the LED badge on the Hero section.
+
+- [ ] **Step 2: Run dev server and verify**
+
+```bash
+npm run dev
+```
+
+Navigate to `http://localhost:3000` and scroll to the Writing section. The panel header should show:
+- `WRITING · LATEST` title (unchanged)
+- A small blinking green LED + `FEED · LIVE` stamp text next to the title
+- `BLOG.CATIVO.DEV →` link on the right (unchanged)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/home/LatestPosts.vue
+git commit -m "feat(latest-posts): add FEED LIVE LED indicator to panel header"
+```
+
+---
+
+### Task 4: BaseInput + BaseTextarea — Variant A Styling
+
+**Files:**
+- Modify: `src/components/base/Input.vue`
+- Modify: `src/components/base/Textarea.vue`
+
+**Design:** Variant A (Bordered Fields) — agreed during brainstorm. Changes are identical in both files.
+
+**Current label class (both files):** `text-nw-cyan font-stamp uppercase tracking-wide font-bold`
+
+**Target label class:** `text-nw-primary font-stamp uppercase tracking-[0.16em] text-[9px]`
+
+**Current inputClasses/textareaClasses:**
+```ts
+'w-full px-3 py-2 bg-void-warm text-nw-text rounded font-sys placeholder-nw-text-dim transition',
+'focus:outline-none focus:ring-2 focus:ring-nw-cyan border',
+props.error ? 'border-nw-red' : 'border-nw-text-line',
+```
+
+**Target inputClasses/textareaClasses:**
+```ts
+'w-full px-3 py-2 bg-void-warm text-nw-text rounded-none font-sys placeholder-nw-text-dim transition',
+'focus:outline-none focus:ring-1 focus:ring-nw-primary focus:border-nw-primary border',
+props.error ? 'border-nw-red' : 'border-nw-primary-dim',
+```
+
+- [ ] **Step 1: Update BaseInput**
+
+In `src/components/base/Input.vue`:
+
+Replace `inputClasses` computed (lines 34–38):
+```ts
+const inputClasses = computed(() => [
+  'w-full px-3 py-2 bg-void-warm text-nw-text rounded font-sys placeholder-nw-text-dim transition',
+  'focus:outline-none focus:ring-2 focus:ring-nw-cyan border',
+  props.error ? 'border-nw-red' : 'border-nw-text-line',
+])
+```
+
+With:
+```ts
+const inputClasses = computed(() => [
+  'w-full px-3 py-2 bg-void-warm text-nw-text rounded-none font-sys placeholder-nw-text-dim transition',
+  'focus:outline-none focus:ring-1 focus:ring-nw-primary focus:border-nw-primary border',
+  props.error ? 'border-nw-red' : 'border-nw-primary-dim',
+])
+```
+
+Replace label class (line 43):
+```html
+<label v-if="label" :for="inputId" class="text-nw-cyan font-stamp uppercase tracking-wide font-bold">
+```
+
+With:
+```html
+<label v-if="label" :for="inputId" class="text-nw-primary font-stamp uppercase tracking-[0.16em] text-[9px]">
+```
+
+- [ ] **Step 2: Update BaseTextarea**
+
+In `src/components/base/Textarea.vue`:
+
+Replace `textareaClasses` computed (lines 34–38):
+```ts
+const textareaClasses = computed(() => [
+  'w-full px-3 py-2 bg-void-warm text-nw-text rounded font-sys placeholder-nw-text-dim transition',
+  'focus:outline-none focus:ring-2 focus:ring-nw-cyan border',
+  props.error ? 'border-nw-red' : 'border-nw-text-line',
+])
+```
+
+With:
+```ts
+const textareaClasses = computed(() => [
+  'w-full px-3 py-2 bg-void-warm text-nw-text rounded-none font-sys placeholder-nw-text-dim transition',
+  'focus:outline-none focus:ring-1 focus:ring-nw-primary focus:border-nw-primary border',
+  props.error ? 'border-nw-red' : 'border-nw-primary-dim',
+])
+```
+
+Replace label class (line 43):
+```html
+<label v-if="label" :for="textareaId" class="text-nw-cyan font-stamp uppercase tracking-wide font-bold">
+```
+
+With:
+```html
+<label v-if="label" :for="textareaId" class="text-nw-primary font-stamp uppercase tracking-[0.16em] text-[9px]">
+```
+
+- [ ] **Step 3: Run dev server and verify**
+
+```bash
+npm run dev
+```
+
+Navigate to `http://localhost:3000` and scroll to the Contact section. All form fields should show:
+- Labels in nw-primary blue (not nw-cyan), smaller and lighter (no bold)
+- Input borders in `nw-primary-dim` (not the faint `nw-text-line`)
+- No border radius (sharp corners)
+- On focus: a 1px ring + border in `nw-primary` (not the 2px cyan ring)
+
+The error state (red border) remains unchanged — no need to test this path visually.
+
+Note: BaseInput and BaseTextarea are also used in the admin login form. After this change, the admin login fields will pick up the same Variant A styling automatically — this is intentional per the design spec (section 1.5 refers to "same treatment as Contact form").
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/base/Input.vue src/components/base/Textarea.vue
+git commit -m "feat(forms): apply Nightwire Variant A styling to BaseInput and BaseTextarea"
+```
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+- ✅ Task 0 — Favicon (added per Carlos's request during session)
+- ✅ Task 1 — Hero: avatar glow + dt labels → nw-primary (spec §2.1)
+- ✅ Task 2 — FeatureProjectCard: featured border-left + glow (spec §2.3)
+- ✅ Task 3 — LatestPosts: FEED·LIVE LED (spec §2.4)
+- ✅ Task 4 — BaseInput + BaseTextarea: Variant A (spec §2.5)
+- ProofOfWork (spec §2.2): "No changes. Already fully Nightwire-compliant." — correctly excluded.
+- Footer (spec §2.6): "No changes. Already fully Nightwire-compliant." — correctly excluded.
+- Hero copy/layout/CTA buttons (spec §2.1 "No changes"): unchanged — correctly excluded.
+
+**Placeholder scan:** No TBDs, TODOs, or incomplete steps. Every code block is complete.
+
+**Type consistency:** No shared types between tasks — each task is self-contained DOM/class changes.

--- a/docs/superpowers/specs/2026-05-24-nightwire-redesign-design.md
+++ b/docs/superpowers/specs/2026-05-24-nightwire-redesign-design.md
@@ -1,0 +1,204 @@
+# Nightwire Redesign — Design Spec
+
+**Date:** 2026-05-24
+**Status:** Approved
+**Approach:** Two PRs — Admin first, Homepage second
+
+---
+
+## Context
+
+The portfolio uses the Nightwire design system (dark cyberpunk, Evangelion-inspired). Two problems:
+
+1. The admin sidebar contains a Blog Posts section that points to non-existent pages (`/admin/blog/*`). The blog lives externally at `blog.cativo.dev` (Ghost CMS) and should not be managed from this admin.
+2. Both the admin and homepage underutilize Nightwire's component patterns — the admin uses generic layout, and the homepage has inconsistencies in token usage (border colors, focus states, label hierarchy).
+
+---
+
+## PR 1 — Admin Redesign
+
+**Branch:** `feature/admin-redesign`
+
+### 1.1 Blog Section Removal
+
+**File:** `src/layouts/admin.vue`
+
+- Remove the Blog Posts entry from `navItems` (lines 100–107)
+- Remove blog-related branches from `currentPageTitle` computed (lines 162–165)
+
+```ts
+// Remove from navItems:
+{
+  path: '/admin/blog',
+  label: 'Blog Posts',
+  icon: 'LucideFileText',
+  children: [
+    { path: '/admin/blog', label: 'All Posts', icon: 'LucideList' },
+    { path: '/admin/blog/new', label: 'New Post', icon: 'LucidePlus' },
+  ],
+},
+
+// Remove from currentPageTitle:
+if (path.startsWith('/admin/blog/new')) return 'Blog / New Post'
+if (path.startsWith('/admin/blog/')) return 'Blog / Edit Post'
+if (path === '/admin/blog') return 'Blog Posts'
+```
+
+### 1.2 Sidebar Redesign
+
+**File:** `src/layouts/admin.vue`
+
+Restyle the sidebar to use Nightwire panel patterns:
+
+- **Logo area**: `border-bottom: 1px solid nw-primary-dim` (panel-header style)
+- **Section label**: small `NAVIGATION` stamp label above nav items (`font-stamp`, `text-[8px]`, `text-nw-primary-dim`, `tracking-[0.18em]`)
+- **Nav items**: `border-left-2` active indicator in `nw-cyan`, bg `nw-cyan/6`, text `nw-cyan`. Inactive: `text-nw-text-dim` hover `text-nw-text`
+- **Nav dot**: 5×5px circle per item, `nw-cyan` with glow when active
+- **Child items**: indented (`pl-7`), 3×3px dot, same active treatment
+- **User section**: avatar initial in `nw-cyan`, email in `text-[9px] text-nw-text-dim`, logout in `text-nw-red/70 hover:text-nw-red`
+
+### 1.3 Dashboard Redesign
+
+**File:** `src/pages/admin/index.vue`
+
+Replace the generic 2-card grid with:
+
+**Metrics strip** (4 cells, 1px gap on `nw-text-faint` background):
+| Cell | Value | Color |
+|------|-------|-------|
+| Projects | count | `nw-green` + glow |
+| Unread | contact count | `nw-yellow` + glow |
+| Users | count | `nw-cyan` + glow |
+| System | `NOMINAL` / LED | `nw-green` |
+
+**Panel pair** below the strip (2-col grid):
+- **Recent Projects** panel: last 3 projects with status badge (`LIVE` / `WIP` / `ALPHA`)
+- **Contacts** panel: last 3 contacts with `UNREAD` / `READ` badge
+
+Remove the "Quick Links" generic card.
+
+> **Implementation note:** The dashboard currently fetches only `projects` and `contacts`. Add a `$fetch('/api/admin/users')` in `onMounted` to populate the Users count cell.
+
+### 1.4 List Pages — nw-table Pattern
+
+**Files:** `src/pages/admin/projects/index.vue`, `src/pages/admin/users/index.vue`, `src/pages/admin/contacts/index.vue`
+
+Apply consistent table structure:
+
+- **Panel wrapper**: `panel` + `panel-header` (section name + record count)
+- **`<th>`**: `font-stamp`, `text-[9px]`, `text-nw-primary`, `tracking-[0.12em]`, `border-bottom border-nw-primary-dim`
+- **`<td>`**: `text-[11px]`, `text-nw-text-dim`, `border-b border-nw-text-faint`
+- **Row hover**: `hover:bg-nw-cyan/4`
+- **Status badges**: inline `font-stamp text-[8px]` with semantic border + background:
+  - `LIVE`: `text-nw-green border-nw-green-dim bg-nw-green-faint`
+  - `WIP`: `text-nw-yellow border-nw-yellow/40 bg-nw-yellow/6`
+  - `UNREAD`: `text-nw-yellow border-nw-yellow/40 bg-nw-yellow/6`
+  - `READ`: `text-[#555] border-[#333]`
+- **Action links**: `font-stamp text-[9px] text-nw-primary-dim hover:text-nw-primary` for EDIT, `text-nw-red/50 hover:text-nw-red` for DELETE
+
+### 1.5 Admin Login Redesign
+
+**File:** `src/pages/admin/login.vue`
+
+- Center-aligned form on `bg-void` full-screen
+- Logo / title: `{ Admin }` in Nightwire panel-header style, centered
+- Input fields: same treatment as Contact form (Variant A — see PR 2)
+- **Password field**: add show/hide toggle with `LucideEye` / `LucideEyeOff` icon button inside the input (right side). Toggle switches `type="password"` ↔ `type="text"`
+- Submit button: full-width `btn` (nw-primary)
+
+---
+
+## PR 2 — Homepage Redesign
+
+**Branch:** `feature/homepage-redesign`
+
+### 2.1 Hero (`src/components/home/Hero.vue`)
+
+**Changes:**
+- **Avatar glow**: add `box-shadow: 0 0 28px rgba(102,153,255,0.18), 0 0 56px rgba(102,153,255,0.07)` to the `<NuxtImg>` element (maps to Tailwind: `shadow-[0_0_28px_rgba(102,153,255,0.18),0_0_56px_rgba(102,153,255,0.07)]`)
+- **ID metadata dt labels**: change from `text-nw-text-dim` → `text-nw-primary` for the `<dt>` elements (OPERATOR / CLEARANCE / UNIT)
+
+**No changes:** Layout, compressed title, hero copy, LED badge, CTA buttons, Japanese subtitle, links row.
+
+### 2.2 ProofOfWork (`src/components/home/ProofOfWork.vue`)
+
+No changes. Already fully Nightwire-compliant.
+
+### 2.3 PortfolioSection / FeatureProjectCard
+
+**File:** `src/components/home/portfolio/FeatureProjectCard.vue`
+
+**Featured card only** (when `featured === true`):
+- Border: change from `border-nw-primary-dim/50` → `border-nw-primary/40`
+- Add left accent: `border-l-[3px] border-l-nw-primary`
+- Add inner glow: `shadow-[inset_3px_0_16px_rgba(102,153,255,0.06),0_4px_24px_rgba(102,153,255,0.07)]`
+
+**Normal cards**: no changes.
+
+### 2.4 LatestPosts (`src/components/home/LatestPosts.vue`)
+
+**Panel header change only:**
+
+Add a `FEED · LIVE` LED indicator next to the title:
+
+```html
+<!-- in panel-header, next to the WRITING · LATEST text -->
+<span class="flex items-center gap-1.5 text-nw-green font-stamp text-[8px] tracking-[0.12em] uppercase">
+  <span class="led green blink" />
+  FEED · LIVE
+</span>
+```
+
+The existing `BLOG.CATIVO.DEV →` link stays on the right.
+
+### 2.5 Contact Form — Variant A (Bordered Fields)
+
+**Files:** `src/components/base/Input.vue`, `src/components/base/Textarea.vue`
+
+**Label changes** (`<label>` element):
+- `text-nw-cyan` → `text-nw-primary`
+- Remove `font-bold`
+- Reduce tracking: `tracking-wide` → `tracking-[0.16em]`
+- Reduce size: add `text-[9px]` override
+
+**Input / Textarea changes:**
+- Border: `border-nw-text-line` → `border-nw-primary-dim`
+- Border radius: `rounded` → `rounded-none`
+- Focus ring: `focus:ring-2 focus:ring-nw-cyan` → `focus:ring-1 focus:ring-nw-primary focus:border-nw-primary`
+
+### 2.6 Footer (`src/components/main/Footer.vue`)
+
+No changes. Already fully Nightwire-compliant.
+
+---
+
+## Files Changed Summary
+
+### PR 1 — Admin
+| File | Change |
+|------|--------|
+| `src/layouts/admin.vue` | Remove blog nav + sidebar redesign |
+| `src/pages/admin/index.vue` | Dashboard metrics-strip + panel pair |
+| `src/pages/admin/login.vue` | Full redesign + password eye toggle |
+| `src/pages/admin/projects/index.vue` | nw-table |
+| `src/pages/admin/users/index.vue` | nw-table |
+| `src/pages/admin/contacts/index.vue` | nw-table |
+
+### PR 2 — Homepage
+| File | Change |
+|------|--------|
+| `src/components/home/Hero.vue` | Avatar glow + dt label color |
+| `src/components/home/portfolio/FeatureProjectCard.vue` | Featured card border-left + glow |
+| `src/components/home/LatestPosts.vue` | FEED·LIVE indicator in panel header |
+| `src/components/base/Input.vue` | Label + border + radius + focus ring |
+| `src/components/base/Textarea.vue` | Label + border + radius + focus ring |
+
+---
+
+## Out of Scope
+
+- Admin pages for projects new/edit forms (forms already work; styling is low priority for now)
+- Any Ghost / blog.cativo.dev integration changes
+- New homepage sections
+- Mobile-specific layout changes
+- Any backend / API changes

--- a/src/layouts/admin.vue
+++ b/src/layouts/admin.vue
@@ -1,39 +1,41 @@
 <template>
   <div class="flex min-h-screen bg-void-warm text-nw-text font-sys">
     <!-- Sidebar -->
-    <aside class="w-60 bg-void-warm border-r border-nw-text-line/20 flex flex-col shrink-0 transition-all duration-300">
+    <aside class="w-60 bg-void-warm border-r border-nw-text-line flex flex-col shrink-0">
       <!-- Logo -->
-      <div class="h-12 flex items-center px-4 border-b border-nw-text-line/20">
-        <NuxtLink to="/admin" class="text-base font-bold font-sys">
-          <span class="text-nw-purple">{</span>
+      <div class="h-10 flex items-center px-4 border-b border-nw-primary-dim shrink-0">
+        <NuxtLink to="/admin" class="font-stamp text-[15px] tracking-[0.12em]">
+          <span class="text-nw-primary">{</span>
           <span class="text-nw-red">Admin</span>
-          <span class="text-nw-purple">}</span>
+          <span class="text-nw-primary">}</span>
         </NuxtLink>
       </div>
 
       <!-- Nav -->
       <nav class="flex-1 py-2 overflow-y-auto">
-        <!-- Main nav items -->
+        <div class="font-stamp text-[8px] tracking-[0.18em] uppercase text-nw-primary-dim px-4 pt-3 pb-1">
+          Navigation
+        </div>
+
         <template v-for="item in navItems" :key="item.path">
           <NuxtLink
             :to="item.path"
-            class="flex items-center gap-3 mx-2 px-3 py-2 rounded-md text-sm transition-colors cursor-pointer"
+            class="flex items-center gap-2.5 pl-4 pr-3 py-[6px] text-[11px] border-l-2 transition-colors cursor-pointer"
             :class="getNavClass(item.path)"
           >
-            <component :is="item.icon" class="w-4 h-4 shrink-0" />
+            <span class="w-[5px] h-[5px] rounded-full shrink-0 transition-all" :class="isActiveRoute(item.path) ? 'bg-nw-cyan shadow-[0_0_5px_theme(colors.nw.cyan.DEFAULT)]' : 'bg-nw-text-dim'" />
             <span>{{ item.label }}</span>
           </NuxtLink>
 
-          <!-- Sub-items for projects -->
-          <div v-if="item.children" class="ml-6 mt-0.5 space-y-0.5">
+          <div v-if="item.children" class="ml-4 mt-0.5">
             <NuxtLink
               v-for="child in item.children"
               :key="child.path"
               :to="child.path"
-              class="flex items-center gap-2 mx-2 px-3 py-1.5 rounded-md text-xs transition-colors cursor-pointer"
+              class="flex items-center gap-2 pl-7 pr-3 py-[5px] text-[10px] border-l-2 transition-colors cursor-pointer"
               :class="getNavChildClass(child.path)"
             >
-              <component :is="child.icon" class="w-3.5 h-3.5 shrink-0" />
+              <span class="w-[3px] h-[3px] rounded-full shrink-0" :class="isExactRoute(child.path) ? 'bg-nw-cyan' : 'bg-nw-text-dim/50'" />
               {{ child.label }}
             </NuxtLink>
           </div>
@@ -41,20 +43,18 @@
       </nav>
 
       <!-- User section -->
-      <div class="p-3 border-t border-nw-text-line/20">
-        <div class="flex items-center gap-2 mb-2 px-2">
-          <div class="w-7 h-7 rounded-full bg-void-raised flex items-center justify-center text-xs font-bold text-nw-cyan">
+      <div class="p-3 border-t border-nw-text-line shrink-0">
+        <div class="flex items-center gap-2 mb-2 px-1">
+          <div class="w-6 h-6 rounded-full bg-void-raised border border-nw-primary-dim flex items-center justify-center text-[10px] font-bold text-nw-cyan shrink-0">
             {{ userInitial }}
           </div>
-          <div class="flex-1 min-w-0">
-            <p class="text-xs text-nw-text truncate">{{ authUser?.email || 'Admin' }}</p>
-          </div>
+          <p class="text-[9px] text-nw-text-dim truncate">{{ authUser?.email || 'Admin' }}</p>
         </div>
         <button
           @click="logout"
-          class="flex items-center gap-2 w-full px-3 py-1.5 rounded-md text-xs text-nw-red/80 hover:bg-nw-red/10 hover:text-nw-red transition-colors"
+          class="flex items-center gap-2 w-full px-2 py-1 text-[10px] font-stamp tracking-[0.1em] uppercase text-nw-red/70 hover:text-nw-red hover:bg-nw-red/[0.06] transition-colors"
         >
-          <LucideLogOut class="w-3.5 h-3.5" />
+          <LucideLogOut class="w-3 h-3" />
           Logout
         </button>
       </div>
@@ -63,12 +63,12 @@
     <!-- Main Content -->
     <div class="flex-1 flex flex-col min-w-0">
       <!-- Top Bar -->
-      <header class="h-12 border-b border-nw-text-line/20 bg-void-warm/50 px-5 flex items-center justify-between shrink-0">
+      <header class="h-10 border-b border-nw-text-line bg-void-warm px-5 flex items-center justify-between shrink-0">
         <div class="flex items-center gap-2">
-          <LucideChevronRight class="w-3.5 h-3.5 text-nw-text-line" />
-          <span class="text-sm text-nw-text-dim font-sys">{{ currentPageTitle }}</span>
+          <span class="text-nw-text-line text-[10px]">›</span>
+          <span class="font-stamp text-[11px] tracking-[0.1em] uppercase text-nw-text-dim">{{ currentPageTitle }}</span>
         </div>
-        <NuxtLink to="/" target="_blank" class="text-xs text-nw-text-dim hover:text-nw-cyan transition-colors flex items-center gap-1">
+        <NuxtLink to="/" target="_blank" class="font-stamp text-[9px] tracking-[0.12em] uppercase text-nw-primary-dim hover:text-nw-primary transition-colors flex items-center gap-1">
           <LucideExternalLink class="w-3 h-3" />
           View site
         </NuxtLink>
@@ -94,15 +94,6 @@ const navItems = ref([
     children: [
       { path: '/admin/projects', label: 'All Projects', icon: 'LucideList' },
       { path: '/admin/projects/new', label: 'New Project', icon: 'LucidePlus' },
-    ],
-  },
-  {
-    path: '/admin/blog',
-    label: 'Blog Posts',
-    icon: 'LucideFileText',
-    children: [
-      { path: '/admin/blog', label: 'All Posts', icon: 'LucideList' },
-      { path: '/admin/blog/new', label: 'New Post', icon: 'LucidePlus' },
     ],
   },
   {
@@ -137,20 +128,18 @@ function isExactRoute(path: string): boolean {
 function getNavClass(path: string): string {
   if (path === '/admin') {
     return isExactRoute(path)
-      ? 'bg-nw-cyan/10 text-nw-cyan font-medium'
-      : 'text-nw-text-dim hover:text-nw-text hover:bg-void-raised/30'
+      ? 'border-l-nw-cyan bg-nw-cyan/[0.06] text-nw-cyan'
+      : 'border-l-transparent text-nw-text-dim hover:text-nw-text hover:bg-void-raised/20'
   }
-  // Parent items: active if route starts with path
   return isActiveRoute(path)
-    ? 'bg-nw-cyan/10 text-nw-cyan font-medium'
-    : 'text-nw-text-dim hover:text-nw-text hover:bg-void-raised/30'
+    ? 'border-l-nw-cyan bg-nw-cyan/[0.06] text-nw-cyan'
+    : 'border-l-transparent text-nw-text-dim hover:text-nw-text hover:bg-void-raised/20'
 }
 
 function getNavChildClass(path: string): string {
-  // Child items: active only on exact match
   return isExactRoute(path)
-    ? 'bg-nw-cyan/10 text-nw-cyan font-medium'
-    : 'text-nw-text-dim hover:text-nw-text hover:bg-void-raised/30'
+    ? 'border-l-nw-cyan bg-nw-cyan/[0.04] text-nw-cyan'
+    : 'border-l-transparent text-nw-text-dim hover:text-nw-text hover:bg-void-raised/10'
 }
 
 const currentPageTitle = computed(() => {
@@ -159,9 +148,6 @@ const currentPageTitle = computed(() => {
   if (path.startsWith('/admin/projects/new')) return 'Projects / New Project'
   if (path.startsWith('/admin/projects/')) return 'Projects / Edit Project'
   if (path === '/admin/projects') return 'Projects'
-  if (path.startsWith('/admin/blog/new')) return 'Blog / New Post'
-  if (path.startsWith('/admin/blog/')) return 'Blog / Edit Post'
-  if (path === '/admin/blog') return 'Blog Posts'
   if (path === '/admin/users') return 'Users'
   if (path === '/admin/contacts') return 'Contacts'
   return 'Admin'

--- a/src/pages/admin/contacts/index.vue
+++ b/src/pages/admin/contacts/index.vue
@@ -1,53 +1,63 @@
 <template>
-  <div>
-    <h1 class="text-xl font-bold text-nw-text mb-6">Contacts</h1>
+  <div class="flex flex-col gap-4">
+    <span class="font-stamp text-[13px] tracking-[0.14em] uppercase text-nw-text">Contacts</span>
 
     <!-- Loading -->
-    <div v-if="loading" class="text-center py-12 text-nw-text-dim font-sys">
-      Loading contacts...
+    <div v-if="loading" class="py-12 text-center font-stamp text-[10px] tracking-wider uppercase text-nw-text-dim">
+      Loading…
     </div>
 
     <!-- Table -->
-    <div v-else-if="contacts.length" class="bg-void-warm border border-nw-text-line/30 rounded-lg overflow-hidden">
-      <table class="w-full text-sm">
-        <thead class="bg-void-warm">
+    <div v-else-if="contacts.length" class="bg-void-warm border border-nw-text-faint">
+      <div class="flex justify-between items-center px-3 py-[7px] border-b border-nw-primary-dim">
+        <span class="font-stamp text-[9px] tracking-[0.14em] uppercase text-nw-primary">All Contacts</span>
+        <span class="font-stamp text-[8px] text-nw-text-dim">{{ contacts.length }} RECORDS</span>
+      </div>
+      <table class="w-full">
+        <thead>
           <tr>
-            <th class="text-left px-4 py-3 text-nw-text-dim font-sys text-xs">Name</th>
-            <th class="text-left px-4 py-3 text-nw-text-dim font-sys text-xs hidden md:table-cell">Email</th>
-            <th class="text-left px-4 py-3 text-nw-text-dim font-sys text-xs hidden lg:table-cell">Message</th>
-            <th class="text-left px-4 py-3 text-nw-text-dim font-sys text-xs hidden md:table-cell">Date</th>
-            <th class="text-center px-4 py-3 text-nw-text-dim font-sys text-xs">Status</th>
-            <th class="text-right px-4 py-3 text-nw-text-dim font-sys text-xs">Actions</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-left px-3 py-[6px] border-b border-nw-primary-dim">Name</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-left px-3 py-[6px] border-b border-nw-primary-dim hidden md:table-cell">Email</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-left px-3 py-[6px] border-b border-nw-primary-dim hidden lg:table-cell">Message</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-left px-3 py-[6px] border-b border-nw-primary-dim hidden md:table-cell">Date</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-center px-3 py-[6px] border-b border-nw-primary-dim">Status</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-right px-3 py-[6px] border-b border-nw-primary-dim">Actions</th>
           </tr>
         </thead>
-        <tbody class="divide-y divide-nw-text-line/20">
-          <tr v-for="contact in contacts" :key="contact.id" class="hover:bg-void-raised/20 transition-colors" :class="!contact.isRead ? 'bg-nw-primary/5' : ''">
-            <td class="px-4 py-3">
-              <span class="text-nw-text font-medium">{{ contact.name }}</span>
+        <tbody>
+          <tr
+            v-for="contact in contacts"
+            :key="contact.id"
+            class="border-b border-nw-text-faint last:border-b-0 hover:bg-nw-cyan/[0.04] transition-colors"
+            :class="!contact.isRead ? 'bg-nw-primary/[0.03]' : ''"
+          >
+            <td class="px-3 py-[7px]">
+              <span class="text-[11px] text-nw-text">{{ contact.name }}</span>
             </td>
-            <td class="px-4 py-3 hidden md:table-cell">
-              <a :href="`mailto:${contact.email}`" class="text-nw-primary hover:underline text-xs">{{ contact.email }}</a>
+            <td class="px-3 py-[7px] hidden md:table-cell">
+              <a :href="`mailto:${contact.email}`" class="text-[10px] text-nw-primary hover:text-nw-primary-hot transition-colors">{{ contact.email }}</a>
             </td>
-            <td class="px-4 py-3 hidden lg:table-cell">
-              <span class="text-nw-text-dim text-xs line-clamp-1">{{ contact.message }}</span>
+            <td class="px-3 py-[7px] hidden lg:table-cell">
+              <span class="text-[10px] text-nw-text-dim line-clamp-1">{{ contact.message }}</span>
             </td>
-            <td class="px-4 py-3 hidden md:table-cell">
-              <span class="text-nw-text-dim text-xs">{{ formatDate(contact.createdAt) }}</span>
+            <td class="px-3 py-[7px] hidden md:table-cell">
+              <span class="text-[10px] text-nw-text-dim">{{ formatDate(contact.createdAt) }}</span>
             </td>
-            <td class="px-4 py-3 text-center">
-              <span class="px-2 py-1 rounded text-xs font-sys" :class="contact.isRead ? 'bg-nw-text-line/20 text-nw-text-dim' : 'bg-nw-yellow/20 text-nw-yellow'">
-                {{ contact.isRead ? 'Read' : 'Unread' }}
+            <td class="px-3 py-[7px] text-center">
+              <span
+                class="font-stamp text-[8px] tracking-[0.1em] uppercase border px-1.5 py-px"
+                :class="contact.isRead ? 'text-[#555] border-[#333]' : 'text-nw-yellow border-nw-yellow/40 bg-nw-yellow/[0.06]'"
+              >
+                {{ contact.isRead ? 'READ' : 'UNREAD' }}
               </span>
             </td>
-            <td class="px-4 py-3 text-right">
-              <div class="flex justify-end gap-2">
-                <button @click="viewContact(contact)" class="text-nw-primary hover:text-nw-cyan text-xs font-sys">
-                  View
-                </button>
-                <button @click="deleteContact(contact.id)" class="text-nw-red hover:text-nw-red/80 text-xs font-sys">
-                  Delete
-                </button>
-              </div>
+            <td class="px-3 py-[7px] text-right">
+              <button @click="viewContact(contact)" class="font-stamp text-[9px] tracking-[0.1em] uppercase text-nw-primary-dim hover:text-nw-primary transition-colors mr-3">
+                VIEW
+              </button>
+              <button @click="deleteContact(contact.id)" class="font-stamp text-[9px] tracking-[0.1em] uppercase text-nw-red/50 hover:text-nw-red transition-colors">
+                DEL
+              </button>
             </td>
           </tr>
         </tbody>
@@ -55,7 +65,7 @@
     </div>
 
     <!-- Empty -->
-    <div v-else class="text-center py-12 text-nw-text-dim font-sys">
+    <div v-else class="py-12 text-center font-stamp text-[10px] tracking-wider uppercase text-nw-text-dim">
       No contacts found.
     </div>
 

--- a/src/pages/admin/index.vue
+++ b/src/pages/admin/index.vue
@@ -45,7 +45,7 @@
           >
             <span class="text-[11px] text-nw-text-dim">{{ project.title }}</span>
             <span class="font-stamp text-[8px] border px-1.5 py-px" :class="projectBadgeClass(project)">
-              {{ project.status || (project.isFeatured ? 'FEATURED' : 'STD') }}
+              {{ (project.status || (project.isFeatured ? 'FEATURED' : 'STD')).toUpperCase() }}
             </span>
           </NuxtLink>
           <div v-if="!recentProjects.length" class="px-3 py-4 text-[10px] text-nw-text-dim font-stamp">

--- a/src/pages/admin/index.vue
+++ b/src/pages/admin/index.vue
@@ -1,42 +1,81 @@
 <template>
-  <div>
-    <h1 class="text-xl font-bold text-nw-text mb-6 font-sys">Dashboard</h1>
+  <div class="flex flex-col gap-4">
+    <div class="font-stamp text-[13px] tracking-[0.14em] uppercase text-nw-text">Dashboard</div>
 
-    <!-- Stats Grid -->
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
-      <div class="bg-void-warm border border-nw-text-line/30 rounded-lg p-6">
-        <div class="flex items-center gap-3 mb-2">
-          <LucideFolderOpen class="w-5 h-5 text-nw-primary" />
-          <h3 class="text-sm text-nw-text-dim font-sys">Projects</h3>
-        </div>
-        <p class="text-3xl font-bold text-nw-text">{{ projectCount }}</p>
+    <!-- Metrics strip -->
+    <div class="grid grid-cols-4 gap-px bg-nw-text-faint border border-nw-text-faint">
+      <div class="bg-void-warm px-4 py-3">
+        <div class="font-stamp text-[9px] tracking-[0.14em] uppercase text-nw-primary mb-1">Projects</div>
+        <div class="text-[24px] font-bold text-nw-green leading-none" style="text-shadow: 0 0 8px rgba(122,237,122,0.35);">{{ projectCount }}</div>
+        <div class="font-stamp text-[8px] text-nw-text-dim mt-1">total</div>
       </div>
-
-      <div class="bg-void-warm border border-nw-text-line/30 rounded-lg p-6">
-        <div class="flex items-center gap-3 mb-2">
-          <LucideMail class="w-5 h-5 text-nw-yellow" />
-          <h3 class="text-sm text-nw-text-dim font-sys">Unread Contacts</h3>
+      <div class="bg-void-warm px-4 py-3">
+        <div class="font-stamp text-[9px] tracking-[0.14em] uppercase text-nw-primary mb-1">Unread</div>
+        <div class="text-[24px] font-bold text-nw-yellow leading-none" style="text-shadow: 0 0 8px rgba(232,153,58,0.35);">{{ unreadContacts }}</div>
+        <div class="font-stamp text-[8px] text-nw-text-dim mt-1">contacts</div>
+      </div>
+      <div class="bg-void-warm px-4 py-3">
+        <div class="font-stamp text-[9px] tracking-[0.14em] uppercase text-nw-primary mb-1">Users</div>
+        <div class="text-[24px] font-bold text-nw-cyan leading-none" style="text-shadow: 0 0 8px rgba(102,221,255,0.3);">{{ userCount }}</div>
+        <div class="font-stamp text-[8px] text-nw-text-dim mt-1">admins</div>
+      </div>
+      <div class="bg-void-warm px-4 py-3">
+        <div class="font-stamp text-[9px] tracking-[0.14em] uppercase text-nw-primary mb-2">System</div>
+        <div class="flex items-center gap-2">
+          <span class="led green blink" />
+          <span class="font-stamp text-[11px] text-nw-green">NOMINAL</span>
         </div>
-        <p class="text-3xl font-bold text-nw-text">{{ unreadContacts }}</p>
       </div>
     </div>
 
-    <!-- Quick Links -->
-    <div class="bg-void-warm border border-nw-text-line/30 rounded-lg p-6">
-      <h2 class="text-sm font-sys text-nw-text-dim mb-4">Quick Links</h2>
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-        <NuxtLink to="/admin/projects" class="flex items-center gap-3 p-3 rounded bg-void-warm hover:bg-void-raised/50 transition-colors">
-          <LucidePlus class="w-4 h-4 text-nw-green" />
-          <span class="text-sm">Add New Project</span>
-        </NuxtLink>
-        <NuxtLink to="/admin/contacts" class="flex items-center gap-3 p-3 rounded bg-void-warm hover:bg-void-raised/50 transition-colors">
-          <LucideInbox class="w-4 h-4 text-nw-primary" />
-          <span class="text-sm">View Contacts</span>
-        </NuxtLink>
-        <NuxtLink to="/" target="_blank" class="flex items-center gap-3 p-3 rounded bg-void-warm hover:bg-void-raised/50 transition-colors">
-          <LucideExternalLink class="w-4 h-4 text-nw-purple" />
-          <span class="text-sm">View Site</span>
-        </NuxtLink>
+    <!-- Panel pair -->
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <!-- Recent Projects -->
+      <div class="bg-void-warm border border-nw-text-faint">
+        <div class="flex justify-between items-center px-3 py-[7px] border-b border-nw-primary-dim">
+          <span class="font-stamp text-[9px] tracking-[0.14em] uppercase text-nw-primary">Recent Projects</span>
+          <span class="font-stamp text-[8px] text-nw-text-dim">CASE FILES</span>
+        </div>
+        <div>
+          <NuxtLink
+            v-for="project in recentProjects"
+            :key="project.id"
+            :to="`/admin/projects/${project.id}`"
+            class="flex items-center justify-between px-3 py-[7px] border-b border-nw-text-faint last:border-b-0 hover:bg-nw-cyan/[0.04] transition-colors"
+          >
+            <span class="text-[11px] text-nw-text-dim">{{ project.title }}</span>
+            <span class="font-stamp text-[8px] border px-1.5 py-px" :class="projectBadgeClass(project)">
+              {{ project.status || (project.isFeatured ? 'FEATURED' : 'STD') }}
+            </span>
+          </NuxtLink>
+          <div v-if="!recentProjects.length" class="px-3 py-4 text-[10px] text-nw-text-dim font-stamp">
+            No projects yet
+          </div>
+        </div>
+      </div>
+
+      <!-- Recent Contacts -->
+      <div class="bg-void-warm border border-nw-text-faint">
+        <div class="flex justify-between items-center px-3 py-[7px] border-b border-nw-primary-dim">
+          <span class="font-stamp text-[9px] tracking-[0.14em] uppercase text-nw-primary">Contacts</span>
+          <span class="font-stamp text-[8px] text-nw-text-dim">INBOX</span>
+        </div>
+        <div>
+          <NuxtLink
+            v-for="contact in recentContacts"
+            :key="contact.id"
+            to="/admin/contacts"
+            class="flex items-center justify-between px-3 py-[7px] border-b border-nw-text-faint last:border-b-0 hover:bg-nw-cyan/[0.04] transition-colors"
+          >
+            <span class="text-[11px] text-nw-text-dim truncate max-w-[160px]">{{ contact.name }}</span>
+            <span class="font-stamp text-[8px] border px-1.5 py-px" :class="contact.isRead ? 'text-[#555] border-[#333]' : 'text-nw-yellow border-nw-yellow/40 bg-nw-yellow/[0.06]'">
+              {{ contact.isRead ? 'READ' : 'UNREAD' }}
+            </span>
+          </NuxtLink>
+          <div v-if="!recentContacts.length" class="px-3 py-4 text-[10px] text-nw-text-dim font-stamp">
+            No contacts yet
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -48,24 +87,41 @@ definePageMeta({
   middleware: ['admin-auth'],
 })
 
+interface DashProject { id: number; title: string; isFeatured?: boolean; status?: string }
+interface DashContact { id: number; name: string; isRead: boolean }
+
 const projectCount = ref(0)
 const unreadContacts = ref(0)
+const userCount = ref(0)
+const recentProjects = ref<DashProject[]>([])
+const recentContacts = ref<DashContact[]>([])
 
-// Load stats from API
+function projectBadgeClass(p: DashProject) {
+  const s = (p.status || '').toLowerCase()
+  if (['live', 'completed', 'production'].includes(s))
+    return 'text-nw-green border-nw-green-dim bg-nw-green-faint'
+  if (['wip', 'active', 'in-progress'].includes(s))
+    return 'text-nw-yellow border-nw-yellow/40 bg-nw-yellow/[0.06]'
+  return 'text-nw-text-dim border-nw-text-line'
+}
+
 onMounted(async () => {
   try {
-    const [projects, contacts] = await Promise.all([
+    const [projects, contacts, users] = await Promise.all([
       $fetch<Record<string, unknown>>('/api/projects').catch(() => ({ data: [] })),
       $fetch<Record<string, unknown>>('/api/admin/contacts').catch(() => ({ data: [] })),
+      $fetch<Record<string, unknown>>('/api/admin/users').catch(() => ({ data: [] })),
     ])
 
-    const projectsData = projects as Record<string, unknown>
-    const contactsData = contacts as Record<string, unknown>
+    const projArray = (projects.data as DashProject[]) || []
+    const contactArray = (contacts.data as DashContact[]) || []
+    const userArray = (users.data as unknown[]) || []
 
-    const projArray = (projectsData.data as unknown[]) || []
-    const contactArray = (contactsData.data as Array<Record<string, unknown>>) || []
     projectCount.value = projArray.length
     unreadContacts.value = contactArray.filter(c => !c.isRead).length
+    userCount.value = userArray.length
+    recentProjects.value = projArray.slice(0, 3)
+    recentContacts.value = contactArray.slice(0, 3)
   } catch { /* ignore */ }
 })
 </script>

--- a/src/pages/admin/login.vue
+++ b/src/pages/admin/login.vue
@@ -1,53 +1,69 @@
 <template>
-  <div class="flex items-center justify-center min-h-screen bg-void-warm">
-    <div class="w-full max-w-md p-8 bg-void-warm border border-nw-text-line/30 rounded-lg">
-      <div class="text-center mb-8">
-        <h1 class="text-2xl font-bold font-sys">
-          <span class="text-nw-purple">{</span>
-          <span class="text-nw-red">Admin</span>
-          <span class="text-nw-purple">}</span>
-        </h1>
-        <p class="text-nw-text-dim text-sm mt-2">Sign in to manage your portfolio</p>
+  <div class="flex items-center justify-center min-h-screen bg-void">
+    <div class="w-full max-w-sm">
+      <!-- Logo -->
+      <div class="border border-nw-primary-dim mb-0">
+        <div class="px-5 py-4 border-b border-nw-primary-dim text-center">
+          <div class="font-stamp text-[18px] tracking-[0.12em]">
+            <span class="text-nw-primary">{</span>
+            <span class="text-nw-red">Admin</span>
+            <span class="text-nw-primary">}</span>
+          </div>
+          <p class="font-stamp text-[9px] tracking-[0.14em] uppercase text-nw-text-dim mt-1">Sign in to manage your portfolio</p>
+        </div>
+
+        <form @submit.prevent="handleLogin" class="p-5 flex flex-col gap-4">
+          <!-- Email -->
+          <div class="flex flex-col gap-1">
+            <label for="email" class="font-stamp text-[9px] tracking-[0.16em] uppercase text-nw-primary">Email</label>
+            <input
+              id="email"
+              v-model="form.email"
+              type="email"
+              required
+              autocomplete="email"
+              placeholder="you@email.com"
+              class="w-full px-3 py-2 bg-void-warm text-nw-text border border-nw-primary-dim rounded-none font-sys text-sm focus:outline-none focus:ring-1 focus:ring-nw-primary focus:border-nw-primary transition-colors"
+            >
+          </div>
+
+          <!-- Password + eye toggle -->
+          <div class="flex flex-col gap-1">
+            <label for="password" class="font-stamp text-[9px] tracking-[0.16em] uppercase text-nw-primary">Password</label>
+            <div class="relative">
+              <input
+                id="password"
+                v-model="form.password"
+                :type="showPassword ? 'text' : 'password'"
+                required
+                autocomplete="current-password"
+                placeholder="••••••••"
+                class="w-full px-3 py-2 pr-10 bg-void-warm text-nw-text border border-nw-primary-dim rounded-none font-sys text-sm focus:outline-none focus:ring-1 focus:ring-nw-primary focus:border-nw-primary transition-colors"
+              >
+              <button
+                type="button"
+                @click="showPassword = !showPassword"
+                class="absolute right-0 top-0 h-full px-3 text-nw-text-dim hover:text-nw-primary transition-colors"
+                :aria-label="showPassword ? 'Hide password' : 'Show password'"
+              >
+                <LucideEye v-if="!showPassword" class="w-4 h-4" />
+                <LucideEyeOff v-else class="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+
+          <p v-if="error" class="font-stamp text-[9px] tracking-[0.1em] uppercase text-nw-red" role="alert">{{ error }}</p>
+
+          <button
+            type="submit"
+            :disabled="loading"
+            class="btn w-full flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <LucideLoader v-if="loading" class="w-4 h-4 animate-spin" />
+            {{ loading ? 'Signing in...' : 'Sign In' }}
+          </button>
+        </form>
       </div>
-
-      <form @submit.prevent="handleLogin" class="space-y-4">
-        <div>
-          <label for="email" class="block text-sm text-nw-cyan font-sys mb-1">Email</label>
-          <input
-            id="email"
-            v-model="form.email"
-            type="email"
-            required
-            autocomplete="email"
-            class="w-full px-3 py-2 bg-void-warm text-nw-text border border-nw-text-line rounded focus:outline-none focus:ring-2 focus:ring-nw-cyan font-sys"
-            placeholder="you@email.com"
-          >
-        </div>
-
-        <div>
-          <label for="password" class="block text-sm text-nw-cyan font-sys mb-1">Password</label>
-          <input
-            id="password"
-            v-model="form.password"
-            type="password"
-            required
-            autocomplete="current-password"
-            class="w-full px-3 py-2 bg-void-warm text-nw-text border border-nw-text-line rounded focus:outline-none focus:ring-2 focus:ring-nw-cyan font-sys"
-            placeholder="••••••••"
-          >
-        </div>
-
-        <p v-if="error" class="text-red-400 text-sm font-sys" role="alert">{{ error }}</p>
-
-        <button
-          type="submit"
-          :disabled="loading"
-          class="w-full px-6 py-2 bg-void-raised text-void-warm font-sys font-bold rounded shadow hover:bg-nw-cyan transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
-        >
-          <LucideLoader v-if="loading" class="w-4 h-4 animate-spin" />
-          {{ loading ? 'Signing in...' : 'Sign In' }}
-        </button>
-      </form>
     </div>
   </div>
 </template>
@@ -61,6 +77,7 @@ definePageMeta({
 const form = reactive({ email: '', password: '' })
 const loading = ref(false)
 const error = ref<string | null>(null)
+const showPassword = ref(false)
 
 async function handleLogin() {
   loading.value = true

--- a/src/pages/admin/projects/index.vue
+++ b/src/pages/admin/projects/index.vue
@@ -1,54 +1,72 @@
 <template>
-  <div>
-    <div class="flex justify-between items-center mb-6">
-      <h1 class="text-xl font-bold text-nw-text">Projects</h1>
-      <NuxtLink to="/admin/projects/new" class="px-4 py-2 bg-nw-green/20 text-nw-green border border-nw-green/30 rounded-lg text-sm font-sys hover:bg-nw-green/30 transition-colors flex items-center gap-2">
-        <LucidePlus class="w-4 h-4" />
+  <div class="flex flex-col gap-4">
+    <!-- Header row -->
+    <div class="flex justify-between items-center">
+      <span class="font-stamp text-[13px] tracking-[0.14em] uppercase text-nw-text">Projects</span>
+      <NuxtLink
+        to="/admin/projects/new"
+        class="btn flex items-center gap-1.5 text-[11px]"
+      >
+        <LucidePlus class="w-3.5 h-3.5" />
         New Project
       </NuxtLink>
     </div>
 
     <!-- Loading -->
-    <div v-if="loading" class="text-center py-12 text-nw-text-dim font-sys">
-      Loading projects...
+    <div v-if="loading" class="py-12 text-center font-stamp text-[10px] tracking-wider uppercase text-nw-text-dim">
+      Loading…
     </div>
 
     <!-- Table -->
-    <div v-else-if="projects.length" class="bg-void-warm border border-nw-text-line/30 rounded-lg overflow-hidden">
-      <table class="w-full text-sm">
-        <thead class="bg-void-warm">
+    <div v-else-if="projects.length" class="bg-void-warm border border-nw-text-faint">
+      <div class="flex justify-between items-center px-3 py-[7px] border-b border-nw-primary-dim">
+        <span class="font-stamp text-[9px] tracking-[0.14em] uppercase text-nw-primary">All Projects</span>
+        <span class="font-stamp text-[8px] text-nw-text-dim">{{ projects.length }} RECORDS</span>
+      </div>
+      <table class="w-full">
+        <thead>
           <tr>
-            <th class="text-left px-4 py-3 text-nw-text-dim font-sys text-xs">Title</th>
-            <th class="text-left px-4 py-3 text-nw-text-dim font-sys text-xs hidden md:table-cell">Status</th>
-            <th class="text-left px-4 py-3 text-nw-text-dim font-sys text-xs hidden lg:table-cell">Tech</th>
-            <th class="text-right px-4 py-3 text-nw-text-dim font-sys text-xs">Actions</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-left px-3 py-[6px] border-b border-nw-primary-dim">Title</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-left px-3 py-[6px] border-b border-nw-primary-dim hidden md:table-cell">Status</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-left px-3 py-[6px] border-b border-nw-primary-dim hidden lg:table-cell">Stack</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-right px-3 py-[6px] border-b border-nw-primary-dim">Actions</th>
           </tr>
         </thead>
-        <tbody class="divide-y divide-nw-text-line/20">
-          <tr v-for="project in projects" :key="project.id" class="hover:bg-void-raised/20 transition-colors">
-            <td class="px-4 py-3">
-              <p class="text-nw-text font-medium">{{ project.title }}</p>
-              <p class="text-nw-text-dim text-xs truncate max-w-xs">{{ project.shortDescription || project.description }}</p>
+        <tbody>
+          <tr
+            v-for="project in projects"
+            :key="project.id"
+            class="border-b border-nw-text-faint last:border-b-0 hover:bg-nw-cyan/[0.04] transition-colors"
+          >
+            <td class="px-3 py-[7px]">
+              <p class="text-[11px] text-nw-text">{{ project.title }}</p>
+              <p class="text-[10px] text-nw-text-dim truncate max-w-xs">{{ project.shortDescription || project.description }}</p>
             </td>
-            <td class="px-4 py-3 hidden md:table-cell">
-              <span class="px-2 py-1 rounded text-xs font-sys" :class="project.isFeatured ? 'bg-nw-purple/20 text-nw-purple' : 'bg-nw-text-line/20 text-nw-text-dim'">
-                {{ project.isFeatured ? 'Featured' : 'Standard' }}
+            <td class="px-3 py-[7px] hidden md:table-cell">
+              <span
+                class="font-stamp text-[8px] tracking-[0.1em] uppercase border px-1.5 py-px"
+                :class="project.isFeatured ? 'text-nw-purple border-nw-purple/40 bg-nw-purple/[0.06]' : 'text-nw-text-dim border-nw-text-line'"
+              >
+                {{ project.isFeatured ? 'FEATURED' : 'STD' }}
               </span>
             </td>
-            <td class="px-4 py-3 hidden lg:table-cell">
+            <td class="px-3 py-[7px] hidden lg:table-cell">
               <div class="flex flex-wrap gap-1">
-                <span v-for="tech in (project.techStack || []).slice(0, 3)" :key="tech" class="text-xs text-nw-green font-sys">
+                <span v-for="tech in (project.techStack || []).slice(0, 3)" :key="tech" class="font-stamp text-[8px] text-nw-cyan">
                   {{ tech }}
                 </span>
-                <span v-if="(project.techStack || []).length > 3" class="text-xs text-nw-text-dim">+{{ (project.techStack || []).length - 3 }}</span>
+                <span v-if="(project.techStack || []).length > 3" class="font-stamp text-[8px] text-nw-text-dim">
+                  +{{ (project.techStack || []).length - 3 }}
+                </span>
               </div>
             </td>
-            <td class="px-4 py-3 text-right">
-              <div class="flex justify-end gap-2">
-                <NuxtLink :to="`/admin/projects/${project.id}`" class="text-nw-primary hover:text-nw-cyan text-xs font-sys">
-                  Edit
-                </NuxtLink>
-              </div>
+            <td class="px-3 py-[7px] text-right">
+              <NuxtLink
+                :to="`/admin/projects/${project.id}`"
+                class="font-stamp text-[9px] tracking-[0.1em] uppercase text-nw-primary-dim hover:text-nw-primary transition-colors"
+              >
+                EDIT
+              </NuxtLink>
             </td>
           </tr>
         </tbody>
@@ -56,7 +74,7 @@
     </div>
 
     <!-- Empty -->
-    <div v-else class="text-center py-12 text-nw-text-dim font-sys">
+    <div v-else class="py-12 text-center font-stamp text-[10px] tracking-wider uppercase text-nw-text-dim">
       No projects found.
     </div>
   </div>

--- a/src/pages/admin/users/index.vue
+++ b/src/pages/admin/users/index.vue
@@ -1,63 +1,66 @@
 <template>
-  <div>
-    <div class="flex items-center justify-between mb-6">
-      <h1 class="text-xl font-bold text-nw-text font-sys">Users</h1>
+  <div class="flex flex-col gap-4">
+    <!-- Header row -->
+    <div class="flex justify-between items-center">
+      <span class="font-stamp text-[13px] tracking-[0.14em] uppercase text-nw-text">Users</span>
       <button
         @click="openCreateModal"
-        class="flex items-center gap-2 px-4 py-2 font-sys text-sm transition-colors border rounded-lg bg-nw-green/20 text-nw-green border-nw-green/30 hover:bg-nw-green/30"
+        class="btn flex items-center gap-1.5 text-[11px]"
       >
-        <LucidePlus class="w-4 h-4" />
+        <LucidePlus class="w-3.5 h-3.5" />
         New User
       </button>
     </div>
 
     <!-- Loading -->
-    <div v-if="loading" class="py-12 font-sys text-center text-nw-text-dim">
-      Loading users...
-    </div>
+    <div v-if="loading" class="py-12 text-center font-stamp text-[10px] tracking-wider uppercase text-nw-text-dim">Loading…</div>
 
     <!-- Error -->
-    <div v-else-if="error" class="py-12 font-sys text-center text-nw-red">
-      {{ error }}
-    </div>
+    <div v-else-if="error" class="py-12 text-center font-stamp text-[10px] tracking-wider uppercase text-nw-red">{{ error }}</div>
 
     <!-- Table -->
-    <div v-else-if="users.length" class="overflow-hidden border rounded-lg bg-void-warm border-nw-text-line/30">
-      <table class="w-full text-sm">
-        <thead class="bg-void-warm">
+    <div v-else-if="users.length" class="bg-void-warm border border-nw-text-faint">
+      <div class="flex justify-between items-center px-3 py-[7px] border-b border-nw-primary-dim">
+        <span class="font-stamp text-[9px] tracking-[0.14em] uppercase text-nw-primary">All Users</span>
+        <span class="font-stamp text-[8px] text-nw-text-dim">{{ users.length }} RECORDS</span>
+      </div>
+      <table class="w-full">
+        <thead>
           <tr>
-            <th class="px-4 py-3 font-sys text-xs text-left text-nw-text-dim">Username</th>
-            <th class="px-4 py-3 font-sys text-xs text-left text-nw-text-dim hidden md:table-cell">Email</th>
-            <th class="px-4 py-3 font-sys text-xs text-left text-nw-text-dim hidden lg:table-cell">Role</th>
-            <th class="px-4 py-3 font-sys text-xs text-left text-nw-text-dim hidden md:table-cell">Created</th>
-            <th class="px-4 py-3 font-sys text-xs text-right text-nw-text-dim">Actions</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-left px-3 py-[6px] border-b border-nw-primary-dim">Username</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-left px-3 py-[6px] border-b border-nw-primary-dim hidden md:table-cell">Email</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-left px-3 py-[6px] border-b border-nw-primary-dim hidden lg:table-cell">Role</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-left px-3 py-[6px] border-b border-nw-primary-dim hidden md:table-cell">Created</th>
+            <th class="font-stamp text-[8px] tracking-[0.14em] uppercase text-nw-primary text-right px-3 py-[6px] border-b border-nw-primary-dim">Actions</th>
           </tr>
         </thead>
-        <tbody class="divide-y divide-nw-text-line/20">
-          <tr v-for="user in users" :key="user.id" class="transition-colors hover:bg-void-raised/20">
-            <td class="px-4 py-3">
-              <p class="font-medium text-nw-text">{{ user.username }}</p>
+        <tbody>
+          <tr
+            v-for="user in users"
+            :key="user.id"
+            class="border-b border-nw-text-faint last:border-b-0 hover:bg-nw-cyan/[0.04] transition-colors"
+          >
+            <td class="px-3 py-[7px]">
+              <span class="text-[11px] text-nw-text">{{ user.username }}</span>
             </td>
-            <td class="px-4 py-3 hidden md:table-cell">
-              <span class="text-xs text-nw-text-dim">{{ user.email }}</span>
+            <td class="px-3 py-[7px] hidden md:table-cell">
+              <span class="text-[10px] text-nw-text-dim">{{ user.email }}</span>
             </td>
-            <td class="px-4 py-3 hidden lg:table-cell">
-              <span class="px-2 py-1 font-sys text-xs rounded bg-nw-cyan/20 text-nw-cyan">
+            <td class="px-3 py-[7px] hidden lg:table-cell">
+              <span class="font-stamp text-[8px] tracking-[0.1em] uppercase border px-1.5 py-px text-nw-cyan border-nw-cyan/30 bg-nw-cyan/[0.06]">
                 {{ user.role || 'admin' }}
               </span>
             </td>
-            <td class="px-4 py-3 hidden md:table-cell">
-              <span class="text-xs text-nw-text-dim">{{ formatDate(user.createdAt || user.created_at) }}</span>
+            <td class="px-3 py-[7px] hidden md:table-cell">
+              <span class="text-[10px] text-nw-text-dim">{{ formatDate(user.createdAt || user.created_at) }}</span>
             </td>
-            <td class="px-4 py-3 text-right">
-              <div class="flex justify-end gap-2">
-                <button @click="openEditModal(user)" class="font-sys text-xs text-nw-primary hover:text-nw-cyan">
-                  Edit
-                </button>
-                <button @click="openDeleteModal(user)" class="font-sys text-xs text-nw-red/70 hover:text-nw-red">
-                  Delete
-                </button>
-              </div>
+            <td class="px-3 py-[7px] text-right">
+              <button @click="openEditModal(user)" class="font-stamp text-[9px] tracking-[0.1em] uppercase text-nw-primary-dim hover:text-nw-primary transition-colors mr-3">
+                EDIT
+              </button>
+              <button @click="openDeleteModal(user)" class="font-stamp text-[9px] tracking-[0.1em] uppercase text-nw-red/50 hover:text-nw-red transition-colors">
+                DEL
+              </button>
             </td>
           </tr>
         </tbody>
@@ -65,9 +68,7 @@
     </div>
 
     <!-- Empty -->
-    <div v-else class="py-12 font-sys text-center text-nw-text-dim">
-      No users found.
-    </div>
+    <div v-else class="py-12 text-center font-stamp text-[10px] tracking-wider uppercase text-nw-text-dim">No users found.</div>
 
     <!-- Create/Edit Modal -->
     <div v-if="modalUser !== undefined" class="fixed inset-0 z-50 flex items-center justify-center bg-black/60" @click.self="closeModal">
@@ -78,46 +79,21 @@
         <form @submit.prevent="saveUser" class="space-y-4">
           <div>
             <label class="block text-sm text-nw-cyan font-sys mb-1">Username</label>
-            <input
-              v-model="form.username"
-              type="text"
-              required
-              :disabled="modalUser !== null"
-              class="w-full px-3 py-2 bg-void-warm text-nw-text border border-nw-text-line rounded focus:outline-none focus:ring-2 focus:ring-nw-cyan font-sys text-sm disabled:opacity-50"
-              :placeholder="modalUser === null ? 'username' : ''"
-            />
+            <input v-model="form.username" type="text" required :disabled="modalUser !== null" class="w-full px-3 py-2 bg-void-warm text-nw-text border border-nw-text-line rounded focus:outline-none focus:ring-2 focus:ring-nw-cyan font-sys text-sm disabled:opacity-50" :placeholder="modalUser === null ? 'username' : ''" />
           </div>
           <div>
             <label class="block text-sm text-nw-cyan font-sys mb-1">Email</label>
-            <input
-              v-model="form.email"
-              type="email"
-              required
-              class="w-full px-3 py-2 bg-void-warm text-nw-text border border-nw-text-line rounded focus:outline-none focus:ring-2 focus:ring-nw-cyan font-sys text-sm"
-              placeholder="user@example.com"
-            />
+            <input v-model="form.email" type="email" required class="w-full px-3 py-2 bg-void-warm text-nw-text border border-nw-text-line rounded focus:outline-none focus:ring-2 focus:ring-nw-cyan font-sys text-sm" placeholder="user@example.com" />
           </div>
           <div>
-            <label class="block text-sm text-nw-cyan font-sys mb-1">
-              {{ modalUser === null ? 'Password' : 'New Password (leave blank to keep)' }}
-            </label>
-            <input
-              v-model="form.password"
-              type="password"
-              :required="modalUser === null"
-              class="w-full px-3 py-2 bg-void-warm text-nw-text border border-nw-text-line rounded focus:outline-none focus:ring-2 focus:ring-nw-cyan font-sys text-sm"
-              :placeholder="modalUser === null ? 'min 6 chars' : ''"
-            />
+            <label class="block text-sm text-nw-cyan font-sys mb-1">{{ modalUser === null ? 'Password' : 'New Password (leave blank to keep)' }}</label>
+            <input v-model="form.password" type="password" :required="modalUser === null" class="w-full px-3 py-2 bg-void-warm text-nw-text border border-nw-text-line rounded focus:outline-none focus:ring-2 focus:ring-nw-cyan font-sys text-sm" :placeholder="modalUser === null ? 'min 6 chars' : ''" />
           </div>
           <p v-if="formError" class="text-red-400 text-sm font-sys" role="alert">{{ formError }}</p>
           <p v-if="formSuccess" class="text-nw-green text-sm font-sys">{{ formSuccess }}</p>
           <div class="flex justify-end gap-3">
-            <button type="button" @click="closeModal" class="px-4 py-2 text-sm text-nw-text-dim hover:text-nw-text transition font-sys">
-              Cancel
-            </button>
-            <button type="submit" :disabled="saving" class="px-4 py-2 text-sm bg-void-raised text-void-warm font-sys font-bold rounded shadow hover:bg-nw-cyan transition disabled:opacity-50">
-              {{ saving ? 'Saving...' : 'Save' }}
-            </button>
+            <button type="button" @click="closeModal" class="px-4 py-2 text-sm text-nw-text-dim hover:text-nw-text transition font-sys">Cancel</button>
+            <button type="submit" :disabled="saving" class="btn text-sm disabled:opacity-50">{{ saving ? 'Saving...' : 'Save' }}</button>
           </div>
         </form>
       </div>
@@ -127,16 +103,10 @@
     <div v-if="deletingUser" class="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
       <div class="bg-void-warm border border-nw-text-line/30 rounded-lg p-6 max-w-sm w-full mx-4">
         <h3 class="text-lg font-bold text-nw-text mb-2">Delete User</h3>
-        <p class="text-sm text-nw-text-dim mb-6">
-          Are you sure you want to delete "<strong class="text-nw-text">{{ deletingUser.username }}</strong>"? This cannot be undone.
-        </p>
+        <p class="text-sm text-nw-text-dim mb-6">Are you sure you want to delete "<strong class="text-nw-text">{{ deletingUser.username }}</strong>"? This cannot be undone.</p>
         <div class="flex justify-end gap-3">
-          <button @click="deletingUser = null" class="px-4 py-2 text-sm text-nw-text-dim hover:text-nw-text transition font-sys">
-            Cancel
-          </button>
-          <button @click="confirmDelete" class="px-4 py-2 text-sm bg-nw-red/20 text-nw-red border border-nw-red/30 rounded hover:bg-nw-red/30 transition font-sys">
-            Delete
-          </button>
+          <button @click="deletingUser = null" class="px-4 py-2 text-sm text-nw-text-dim hover:text-nw-text transition font-sys">Cancel</button>
+          <button @click="confirmDelete" class="btn-danger text-sm">Delete</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Removes Blog Posts section from admin nav (those pages never existed — blog lives at blog.cativo.dev)
- Sidebar restyled with Nightwire panel patterns: left-border active indicator, nav dots with glow, NAVIGATION stamp section label
- Dashboard replaced generic 2-card grid with a 4-cell metrics strip (Projects/Unread/Users/System with green LED) + Recent Projects and Contacts panels
- Projects, Contacts, and Users lists now use the nw-table pattern: blue stamp headers, compact rows, semantic status badges, stamp EDIT/DEL links
- Login page fully redesigned: void background, panel-border layout, nw-primary-dim inputs, sharp corners, password show/hide eye toggle

## Test plan
- [ ] Blog Posts is absent from admin sidebar
- [ ] Sidebar active items show cyan left-border + glowing dot
- [ ] Dashboard 4-cell metrics strip renders; System cell shows green LED + NOMINAL
- [ ] Recent Projects and Contacts panels show up to 3 rows each
- [ ] Projects table: blue stamp headers, FEATURED/STD badge, EDIT stamp link
- [ ] Contacts table: UNREAD rows have yellow badge; READ rows are muted
- [ ] Users table: Role badge is cyan, DEL button uses btn-danger in delete confirm modal
- [ ] Login: centered on void background, inputs have nw-primary-dim border, sharp corners
- [ ] Login: eye icon toggles password visibility correctly