### PR TITLE
feat(homepage): Nightwire redesign — favicon, hero, portfolio, feed, forms

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -60,6 +60,7 @@ export default defineNuxtConfig({
         class: "antialiased bg-void text-nw-text font-sys min-h-screen",
       },
       link: [
+        { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' },
         { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
         { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' },
         {

--- a/src/components/base/Input.vue
+++ b/src/components/base/Input.vue
@@ -32,15 +32,15 @@ const inputId = computed(() => {
 const errorId = computed(() => props.error && inputId.value ? `${inputId.value}-error` : undefined)
 
 const inputClasses = computed(() => [
-  'w-full px-3 py-2 bg-void-warm text-nw-text rounded font-sys placeholder-nw-text-dim transition',
-  'focus:outline-none focus:ring-2 focus:ring-nw-cyan border',
-  props.error ? 'border-nw-red' : 'border-nw-text-line',
+  'w-full px-3 py-2 bg-void-warm text-nw-text rounded-none font-sys placeholder-nw-text-dim transition',
+  'focus:outline-none focus:ring-1 focus:ring-nw-primary focus:border-nw-primary border',
+  props.error ? 'border-nw-red' : 'border-nw-primary-dim',
 ])
 </script>
 
 <template>
   <div class="flex flex-col gap-1">
-    <label v-if="label" :for="inputId" class="text-nw-cyan font-stamp uppercase tracking-wide font-bold">
+    <label v-if="label" :for="inputId" class="text-nw-primary font-stamp uppercase tracking-[0.16em] text-[9px]">
       {{ label }}
     </label>
     <input

--- a/src/components/base/Textarea.vue
+++ b/src/components/base/Textarea.vue
@@ -32,15 +32,15 @@ const textareaId = computed(() => {
 const errorId = computed(() => props.error && textareaId.value ? `${textareaId.value}-error` : undefined)
 
 const textareaClasses = computed(() => [
-  'w-full px-3 py-2 bg-void-warm text-nw-text rounded font-sys placeholder-nw-text-dim transition',
-  'focus:outline-none focus:ring-2 focus:ring-nw-cyan border',
-  props.error ? 'border-nw-red' : 'border-nw-text-line',
+  'w-full px-3 py-2 bg-void-warm text-nw-text rounded-none font-sys placeholder-nw-text-dim transition',
+  'focus:outline-none focus:ring-1 focus:ring-nw-primary focus:border-nw-primary border',
+  props.error ? 'border-nw-red' : 'border-nw-primary-dim',
 ])
 </script>
 
 <template>
   <div class="flex flex-col gap-1">
-    <label v-if="label" :for="textareaId" class="text-nw-cyan font-stamp uppercase tracking-wide font-bold">
+    <label v-if="label" :for="textareaId" class="text-nw-primary font-stamp uppercase tracking-[0.16em] text-[9px]">
       {{ label }}
     </label>
     <textarea

--- a/src/components/home/Hero.vue
+++ b/src/components/home/Hero.vue
@@ -75,15 +75,15 @@
               width="180"
               height="180"
               loading="eager"
-              class="relative w-[180px] h-[180px] object-cover border border-nw-primary-dim"
+              class="relative w-[180px] h-[180px] object-cover border border-nw-primary-dim shadow-[0_0_28px_rgba(102,153,255,0.18),0_0_56px_rgba(102,153,255,0.07)]"
               style="border-radius: 0;"
               quality="80"
             />
           </div>
           <dl class="mt-3 font-stamp uppercase tracking-wider text-[9px] text-nw-text-dim space-y-0.5">
-            <div class="flex justify-between gap-2"><dt>OPERATOR</dt><dd class="text-nw-text">CATIVO-01</dd></div>
-            <div class="flex justify-between gap-2"><dt>CLEARANCE</dt><dd class="text-nw-text">TECH-LEAD</dd></div>
-            <div class="flex justify-between gap-2"><dt>UNIT</dt><dd class="text-nw-text">BLUE-MEDICAL-GT</dd></div>
+            <div class="flex justify-between gap-2"><dt class="text-nw-primary">OPERATOR</dt><dd class="text-nw-text">CATIVO-01</dd></div>
+            <div class="flex justify-between gap-2"><dt class="text-nw-primary">CLEARANCE</dt><dd class="text-nw-text">TECH-LEAD</dd></div>
+            <div class="flex justify-between gap-2"><dt class="text-nw-primary">UNIT</dt><dd class="text-nw-text">BLUE-MEDICAL-GT</dd></div>
           </dl>
         </aside>
       </div>

--- a/src/components/home/LatestPosts.vue
+++ b/src/components/home/LatestPosts.vue
@@ -1,7 +1,13 @@
 <template>
   <div class="panel">
     <div class="panel-header">
-      <span>WRITING · LATEST</span>
+      <div class="flex items-center gap-3">
+        <span>WRITING · LATEST</span>
+        <span class="flex items-center gap-1.5 text-nw-green font-stamp text-[8px] tracking-[0.12em] uppercase">
+          <span class="led green blink" />
+          FEED · LIVE
+        </span>
+      </div>
       <a
         href="https://blog.cativo.dev"
         target="_blank"

--- a/src/components/home/LatestPosts.vue
+++ b/src/components/home/LatestPosts.vue
@@ -4,7 +4,7 @@
       <div class="flex items-center gap-3">
         <span>WRITING · LATEST</span>
         <span class="flex items-center gap-1.5 text-nw-green font-stamp text-[8px] tracking-[0.12em] uppercase">
-          <span class="led green blink" />
+          <span class="led green blink" aria-hidden="true" />
           FEED · LIVE
         </span>
       </div>

--- a/src/components/home/portfolio/FeatureProjectCard.vue
+++ b/src/components/home/portfolio/FeatureProjectCard.vue
@@ -2,9 +2,11 @@
   <NuxtLink
     :to="`/projects/${project.id}`"
     :class="[
-      'bg-void-raised hover:bg-void-panel border hover:border-nw-primary-dim transition-all duration-200 p-5 flex flex-col gap-3',
-      featured ? 'border-nw-primary-dim/50' : 'border-nw-text-line',
-      'hover:-translate-y-0.5 hover:shadow-[0_4px_20px_rgba(102,153,255,0.08)]',
+      'bg-void-raised hover:bg-void-panel border transition-all duration-200 p-5 flex flex-col gap-3',
+      featured
+        ? 'border-nw-primary/40 border-l-[3px] border-l-nw-primary shadow-[inset_3px_0_16px_rgba(102,153,255,0.06),0_4px_24px_rgba(102,153,255,0.07)] hover:border-nw-primary-hot/50'
+        : 'border-nw-text-line hover:border-nw-primary-dim',
+      'hover:-translate-y-0.5',
     ]"
   >
     <header class="flex items-start justify-between gap-3">

--- a/src/public/favicon.svg
+++ b/src/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#000000"/>
+  <rect x="1" y="1" width="30" height="30" fill="none" stroke="#4477cc" stroke-width="1"/>
+  <path d="M22 10 Q10 10 10 16 Q10 22 22 22" stroke="#6699ff" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- New Nightwire SVG favicon: void background, nw-primary-dim panel border, nw-primary C initial. Declared first in head so browsers prefer it over the legacy .ico fallback.
- Hero: avatar gets subtle nw-primary outer glow; OPERATOR/CLEARANCE/UNIT dt labels upgraded from dim grey to nw-primary blue
- FeatureProjectCard: featured card gets 3px nw-primary left accent + inner glow shadow; normal cards unchanged
- LatestPosts: FEED · LIVE blinking green LED added next to panel header title
- BaseInput + BaseTextarea: Variant A styling — labels nw-primary/9px/no-bold, borders nw-primary-dim, sharp corners (rounded-none), focus ring 1px nw-primary

## Test plan
- [ ] Browser tab shows the new dark C favicon (not the old generic one)
- [ ] Hero avatar has a subtle blue outer glow
- [ ] Hero OPERATOR / CLEARANCE / UNIT labels are nw-primary blue (not dim grey)
- [ ] Featured project card has a visible 3px left blue accent and a soft inner glow
- [ ] Normal project cards look unchanged
- [ ] LatestPosts panel header shows blinking green LED + FEED · LIVE text
- [ ] Contact form labels are nw-primary, smaller, not bold
- [ ] Contact form inputs have nw-primary-dim border, no border radius
- [ ] Contact form focus state shows a 1px nw-primary ring (not the wide cyan ring)
- [ ] Admin login inputs also pick up the Variant A styling (BaseInput is shared)