### PR TITLE
🚀 Release 1.10.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.15] - 2026-05-24
+
+### Fixed
+- ProofOfWork section now responsive on mobile: heatmap and stats grid stack vertically below md breakpoint, NPM sparkline strip wraps correctly on narrow viewports
+
+---
+
 ## [1.10.14] - 2026-05-24
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-app",
-  "version": "1.10.13",
+  "version": "1.10.15",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/components/home/ProofOfWork.vue
+++ b/src/components/home/ProofOfWork.vue
@@ -6,7 +6,7 @@
     </div>
 
     <!-- Row 1: Heatmap with month axis + Stats Grid 2x3 -->
-    <div class="flex items-stretch border-b border-nw-text-faint">
+    <div class="flex flex-col md:flex-row items-stretch border-b border-nw-text-faint">
       <!-- Heatmap zone (flex-grow, responsive cells) -->
       <div class="flex-grow px-5 py-4 flex flex-col justify-center gap-1 overflow-hidden">
         <div v-if="signal?.github.weeks.length" class="heatmap-grid w-full">
@@ -33,7 +33,7 @@
       </div>
 
       <!-- Stats grid 2x3 -->
-      <div class="grid grid-cols-2 gap-px bg-nw-text-faint shrink-0 w-[340px]">
+      <div class="grid grid-cols-3 md:grid-cols-2 gap-px bg-nw-text-faint border-t border-nw-text-faint md:border-t-0 md:shrink-0 md:w-[340px]">
         <div class="metric-cell">
           <div class="m-value" style="color: var(--nw-green); text-shadow: 0 0 6px rgba(122,237,122,0.3);">
             {{ signal?.github.contributions ?? '...' }}
@@ -75,9 +75,9 @@
     </div>
 
     <!-- Row 2: NPM Sparkline Strip -->
-    <div v-if="npmPackages.length" class="flex items-center px-5 py-2.5 gap-8 border-b border-nw-text-faint">
+    <div v-if="npmPackages.length" class="flex flex-wrap items-center px-5 py-2.5 gap-4 md:gap-8 border-b border-nw-text-faint">
       <span class="font-stamp uppercase tracking-wider text-[8px] text-nw-text-dim shrink-0">NPM Downloads</span>
-      <div class="flex items-center gap-8 flex-grow justify-around">
+      <div class="flex flex-wrap items-center gap-4 md:gap-8 md:flex-grow justify-start md:justify-around">
         <div v-for="pkg in npmPackages" :key="pkg.name" class="flex items-center gap-3">
           <span class="font-stamp uppercase tracking-wider text-[9px] text-nw-text-dim">{{ pkg.name }}</span>
           <div class="sparkline">


### PR DESCRIPTION
## Summary

Fixes a responsive layout regression in the ProofOfWork section where the heatmap, stats grid, and NPM sparkline strip did not reflow correctly on mobile viewports below the md breakpoint.

## Highlights

### Fixed
- ProofOfWork section now responsive on mobile: heatmap and stats grid stack vertically below md breakpoint, NPM sparkline strip wraps correctly on narrow viewports

## Test plan

- [x] CI `build` green on source PRs
- [ ] Post-merge: auto-release tags `v1.10.15` and publishes GitHub Release
- [ ] Post-merge: Deploy workflow succeeds on polaris2
- [ ] Post-deploy: `curl -I https://cativo.dev/` shows expected headers
- [ ] Post-deploy: container reports `healthy`
- [ ] Post-release: `main` merged back to `develop`