### PR TITLE
Release 1.10.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.16] - 2026-05-28
+
+### Fixed
+- **ProofOfWork npm data** — Signal API was fetching downloads for `claude-setup`, a package not owned by this account, inflating the total DL count. Replaced with `claude-style` (own package). NPM Packages metric corrected from hardcoded `2` → `4` (actual published count: lumira, nightwire, claude-style, claudesm).
+
+### Added
+- **Sparkline tooltips** — Hovering any bar in the NPM Downloads sparkline strip now shows a small tooltip with the weekly download count for that week.
+
+### Changed
+- **About & CV content refresh** — Updated lumira (~3.4K dl/mo) and nightwire (~475 dl/mo) download counts and descriptions to reflect current reality. Removed `claude-style` as a separate OSS entry (low traction). CV role title, summary, and LinkedIn URL updated.
+
+---
+
 ## [1.10.15] - 2026-05-24
 
 ### Fixed

--- a/src/components/home/ProofOfWork.vue
+++ b/src/components/home/ProofOfWork.vue
@@ -54,7 +54,7 @@
         </div>
         <div class="metric-cell">
           <div class="m-value" style="color: var(--nw-primary); text-shadow: 0 0 6px rgba(102,153,255,0.3);">
-            3
+            4
           </div>
           <div class="m-label">NPM Packages</div>
         </div>
@@ -85,6 +85,7 @@
               v-for="(val, i) in pkg.weekly"
               :key="i"
               class="spark-bar"
+              :data-tip="formatNumber(val)"
               :style="{
                 height: sparkBarHeight(val, pkg.weekly) + 'px',
                 background: val === sparkMax(pkg.weekly) ? 'var(--nw-primary)' : 'var(--nw-primary-dim)',
@@ -145,7 +146,7 @@ interface NpmPackageData {
 
 interface SignalData {
   github: { contributions: number; weeks: number[][]; publicRepos: number }
-  npm: { lumira: NpmPackageData | number; claudeSetup: NpmPackageData | number; nightwire: NpmPackageData | number; total: number }
+  npm: { lumira: NpmPackageData | number; claudeStyle: NpmPackageData | number; nightwire: NpmPackageData | number; total: number }
   api: { version: string; status: string }
 }
 
@@ -165,11 +166,9 @@ const npmPackages = computed(() => {
   if (!signal.value) return []
   const lumira = getNpmPkg(signal.value.npm.lumira)
   const nightwire = getNpmPkg(signal.value.npm.nightwire)
-  const claudeSetup = getNpmPkg(signal.value.npm.claudeSetup)
   return [
     { name: 'Lumira', ...lumira },
     { name: 'Nightwire', ...nightwire },
-    { name: 'Claude-Setup', ...claudeSetup },
   ].filter(p => p.monthly > 0 || p.weekly.length > 0)
 })
 
@@ -247,10 +246,35 @@ function formatNumber(n: number | undefined): string {
   align-items: flex-end;
   gap: 2px;
   height: 24px;
+  overflow: visible;
 }
 .spark-bar {
+  position: relative;
   width: 6px;
   border-radius: 1px;
   min-height: 3px;
+  cursor: default;
+}
+.spark-bar::after {
+  content: attr(data-tip);
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: #0a0a12;
+  border: 1px solid rgba(102, 153, 255, 0.35);
+  color: var(--nw-primary);
+  font-family: var(--font-stamp, monospace);
+  font-size: 8px;
+  letter-spacing: 0.06em;
+  padding: 2px 5px;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.12s;
+  z-index: 20;
+}
+.spark-bar:hover::after {
+  opacity: 1;
 }
 </style>

--- a/src/pages/about.vue
+++ b/src/pages/about.vue
@@ -333,21 +333,15 @@ const profile: Profile = {
 const ossPackages = [
   {
     name: 'lumira',
-    downloads: '~1.9K dl/mo',
+    downloads: '~3.4K dl/mo',
     stack: 'TypeScript · npm',
-    description: 'Claude Code workflow tooling — status line, hooks, helpers for daily AI-assisted development.'
-  },
-  {
-    name: 'claude-style',
-    downloads: '~850 dl/mo',
-    stack: 'TypeScript · npm',
-    description: 'Style and formatting primitives for Claude Code agents and CLI output.'
+    description: 'Real-time statusline HUD for Claude Code and Qwen Code. Session analytics, latency overhead widget, quota projection. Zero deps.'
   },
   {
     name: 'nightwire',
-    downloads: '~200 dl/mo',
-    stack: 'TypeScript · npm',
-    description: 'Agent orchestration utilities for multi-step Claude workflows.'
+    downloads: '~475 dl/mo',
+    stack: 'CSS · npm',
+    description: 'Dark cyberpunk UI design system. Semantic color roles, neon palette, CLI installer.'
   }
 ]
 

--- a/src/pages/cv.vue
+++ b/src/pages/cv.vue
@@ -33,7 +33,7 @@ const print = () => {
     <main class="cv">
       <header class="head">
         <h1>Carlos Cativo</h1>
-        <p class="role">Senior Backend Engineer · Tech Lead</p>
+        <p class="role">Senior Tech Lead — Payments, Healthcare Platforms &amp; Backend Architecture</p>
         <p class="contact">
           <a href="mailto:cativo@cativo.dev">cativo@cativo.dev</a>
           <span class="sep">·</span>
@@ -45,17 +45,14 @@ const print = () => {
           <span class="sep">·</span>
           <a href="https://github.com/cativo23" target="_blank" rel="noopener">github.com/cativo23</a>
           <span class="sep">·</span>
-          <a href="https://www.linkedin.com/in/cativo23" target="_blank" rel="noopener">linkedin.com/in/cativo23</a>
+          <a href="https://www.linkedin.com/in/carlos-cativo" target="_blank" rel="noopener">linkedin.com/in/carlos-cativo</a>
         </p>
       </header>
 
       <section>
         <h2>Summary</h2>
         <p class="summary">
-          Tech Lead with 9 years building production backend systems — payment processing, e-invoicing,
-          subscription platforms, and conversational AI. Strongest in Laravel/PHP and TypeScript/NestJS,
-          comfortable across the stack and the infrastructure underneath. Open to senior backend, tech lead,
-          and staff roles, remote-first, with sponsorship for relocation.
+          Tech Lead with 9 years building production backend systems, currently leading a team of 5 engineers at Blue Medical Guatemala. Scaled a payment platform from ~$30K to ~$450K USD/mo while shipping 3 services from scratch: a multi-gateway payment processor (VGS tokenization, PCI-DSS scope reduction), an electronic invoicing system with SAP integration, and a multi-agent AI voice product. Stack-fluid across Laravel/PHP, TypeScript/NestJS, and Python/FastAPI. Open to Senior Backend, Tech Lead, and Engineering Manager roles — remote-first or with relocation sponsorship.
         </p>
       </section>
 
@@ -161,16 +158,13 @@ const print = () => {
         <h2>Open Source · npm</h2>
         <ul class="projects">
           <li>
-            <strong>lumira</strong> <span class="proj-tag">~1.9K dl/mo</span> — Claude Code workflow tooling
-            (status line, hooks, helpers). <em>TypeScript, npm.</em>
+            <strong>lumira</strong> <span class="proj-tag">~3.4K dl/mo</span> — Real-time statusline HUD
+            for Claude Code and Qwen Code. Session analytics, latency overhead widget, quota projection.
+            Zero deps. <em>TypeScript, npm.</em>
           </li>
           <li>
-            <strong>claude-style</strong> <span class="proj-tag">~850 dl/mo</span> — Style and formatting
-            primitives for Claude Code agents. <em>TypeScript, npm.</em>
-          </li>
-          <li>
-            <strong>nightwire</strong> <span class="proj-tag">~200 dl/mo</span> — Agent orchestration utilities
-            for multi-step Claude workflows. <em>TypeScript, npm.</em>
+            <strong>nightwire</strong> <span class="proj-tag">~475 dl/mo</span> — Dark cyberpunk UI design
+            system. Semantic color roles, neon palette, CLI installer. <em>CSS, npm.</em>
           </li>
         </ul>
       </section>

--- a/src/server/api/signal.get.ts
+++ b/src/server/api/signal.get.ts
@@ -11,7 +11,7 @@ interface SignalData {
   }
   npm: {
     lumira: NpmPackageData
-    claudeSetup: NpmPackageData
+    claudeStyle: NpmPackageData
     nightwire: NpmPackageData
     total: number
   }
@@ -121,11 +121,11 @@ async function fetchApiHealth(): Promise<{ version: string; status: string }> {
 export default defineCachedEventHandler(
   async (event) => {
     const { githubToken } = useRuntimeConfig(event)
-    const [gh, repos, lumira, claudeSetup, nightwire, api] = await Promise.allSettled([
+    const [gh, repos, lumira, claudeStyle, nightwire, api] = await Promise.allSettled([
       fetchGitHubContributions(githubToken),
       fetchGitHubRepos(githubToken),
       fetchNpmDownloads('lumira'),
-      fetchNpmDownloads('claude-setup'),
+      fetchNpmDownloads('claude-style'),
       fetchNpmDownloads('@cativo23/nightwire'),
       fetchApiHealth(),
     ])
@@ -134,7 +134,7 @@ export default defineCachedEventHandler(
     const repoCount = repos.status === 'fulfilled' ? repos.value : 0
     const fallbackPkg: NpmPackageData = { monthly: 0, weekly: [0, 0, 0, 0, 0, 0, 0] }
     const lumiraDl = lumira.status === 'fulfilled' ? lumira.value : fallbackPkg
-    const claudeSetupDl = claudeSetup.status === 'fulfilled' ? claudeSetup.value : fallbackPkg
+    const claudeStyleDl = claudeStyle.status === 'fulfilled' ? claudeStyle.value : fallbackPkg
     const nightwireDl = nightwire.status === 'fulfilled' ? nightwire.value : fallbackPkg
     const apiData = api.status === 'fulfilled' ? api.value : { version: '...', status: 'unknown' }
 
@@ -146,9 +146,9 @@ export default defineCachedEventHandler(
       },
       npm: {
         lumira: lumiraDl,
-        claudeSetup: claudeSetupDl,
+        claudeStyle: claudeStyleDl,
         nightwire: nightwireDl,
-        total: lumiraDl.monthly + claudeSetupDl.monthly + nightwireDl.monthly,
+        total: lumiraDl.monthly + claudeStyleDl.monthly + nightwireDl.monthly,
       },
       api: apiData,
     }


### PR DESCRIPTION
## Summary

Fixed ProofOfWork npm data source (replaced non-owned claude-setup with claude-style), added sparkline tooltips, and refreshed About/CV content with current package download counts.

## Highlights

- **ProofOfWork npm data** — Signal API was fetching downloads for `claude-setup`, a package not owned by this account, inflating the total DL count. Replaced with `claude-style` (own package). NPM Packages metric corrected from hardcoded `2` → `4` (actual published count: lumira, nightwire, claude-style, claudesm).
- **Sparkline tooltips** — Hovering any bar in the NPM Downloads sparkline strip now shows a small tooltip with the weekly download count for that week.
- **About & CV content refresh** — Updated lumira (~3.4K dl/mo) and nightwire (~475 dl/mo) download counts and descriptions to reflect current reality. Removed `claude-style` as a separate OSS entry (low traction). CV role title, summary, and LinkedIn URL updated.

## Test plan

- [x] CI `build` green on source PRs
- [ ] Post-merge: auto-release tags `v1.10.16` and publishes GitHub Release
- [ ] Post-merge: Deploy workflow succeeds on polaris2
- [ ] Post-deploy: `curl -I https://cativo.dev/` shows expected headers
- [ ] Post-deploy: container reports `healthy`
- [ ] Post-release: `main` merged back to `develop`