### PR TITLE
feat(chat): add AI assistant chat widget

### DIFF
--- a/src/components/chat/Composer.vue
+++ b/src/components/chat/Composer.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+
+const props = defineProps<{ loading?: boolean; cooldown?: number }>()
+const emit = defineEmits<{ send: [text: string] }>()
+
+const text = ref('')
+
+const blocked = computed(() => !!props.loading || (props.cooldown ?? 0) > 0)
+const canSend = computed(
+  () => !blocked.value && text.value.trim().length >= 1,
+)
+
+const sendLabel = computed(() =>
+  (props.cooldown ?? 0) > 0 ? `WAIT ${props.cooldown}s` : 'SEND',
+)
+
+function onSend() {
+  if (!canSend.value) return
+  emit('send', text.value.trim())
+  text.value = ''
+}
+</script>
+
+<template>
+  <div class="flex items-end gap-2 border-t border-nw-faint bg-void-warm p-3">
+    <textarea
+      v-model="text"
+      :disabled="blocked"
+      rows="2"
+      maxlength="500"
+      placeholder="Ask about Carlos…"
+      aria-label="Ask the assistant a question about Carlos"
+      class="w-full resize-none rounded-none border border-nw-primary-dim bg-void-warm px-3 py-2 font-sys text-sm text-nw-text placeholder-nw-text-dim transition focus:border-nw-primary focus:outline-none focus:ring-1 focus:ring-nw-primary disabled:opacity-50"
+      @keydown.enter.exact.prevent="onSend"
+    />
+    <BaseButton
+      type="button"
+      variant="primary"
+      size="sm"
+      :loading="loading"
+      :disabled="!canSend"
+      @click="onSend"
+    >
+      {{ sendLabel }}
+    </BaseButton>
+  </div>
+</template>

--- a/src/components/chat/Message.vue
+++ b/src/components/chat/Message.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { ChatMessage } from '@/composables/useChatAssistant'
+
+const props = defineProps<{ message: ChatMessage }>()
+
+const isUser = computed(() => props.message.role === 'user')
+const isAssistant = computed(() => props.message.role === 'assistant')
+const isRateLimit = computed(() => props.message.variant === 'rate-limit')
+const isError = computed(
+  () => props.message.role === 'error' && !isRateLimit.value,
+)
+
+const label = computed(() => {
+  if (isUser.value) return 'OPERATOR'
+  if (isAssistant.value) return 'AI DEBRIEF'
+  if (isRateLimit.value) return 'RATE LIMIT'
+  return 'ERROR'
+})
+
+const bubbleClass = computed(() => {
+  if (isUser.value)
+    return 'ml-8 bg-void-raised border border-nw-line text-nw-text'
+  if (isAssistant.value)
+    return 'mr-8 bg-void-panel border border-nw-ai-mute text-nw-text-dim shadow-[0_0_8px_rgba(178,102,224,0.12)]'
+  if (isRateLimit.value)
+    return 'bg-nw-yellow/10 border border-nw-yellow text-nw-yellow'
+  return 'bg-nw-red-fill border border-nw-red text-nw-red'
+})
+
+const labelClass = computed(() => {
+  if (isUser.value) return 'text-nw-primary'
+  if (isAssistant.value) return 'text-nw-ai'
+  if (isRateLimit.value) return 'text-nw-yellow'
+  return 'text-nw-red'
+})
+</script>
+
+<template>
+  <div :class="['flex', isUser ? 'justify-end' : 'justify-start']">
+    <div :class="['max-w-[85%] rounded-nw-sm px-3 py-2', bubbleClass]">
+      <span
+        :class="[
+          'block font-stamp uppercase tracking-[0.14em] text-[9px] mb-1',
+          labelClass,
+        ]"
+      >
+        <template v-if="isError || isRateLimit">{{ isRateLimit ? '⚠' : '✕' }} </template>{{ label }}
+      </span>
+      <p class="font-sys text-sm whitespace-pre-wrap break-words">
+        {{ message.content }}
+      </p>
+    </div>
+  </div>
+</template>

--- a/src/components/chat/TypingIndicator.vue
+++ b/src/components/chat/TypingIndicator.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+const delays = ['0ms', '200ms', '400ms']
+</script>
+
+<template>
+  <div class="flex justify-start">
+    <div
+      class="mr-8 flex items-center gap-2 rounded-nw-sm border border-nw-ai-mute bg-void-panel px-3 py-2"
+    >
+      <span
+        v-for="(delay, i) in delays"
+        :key="i"
+        class="h-1.5 w-1.5 rounded-full bg-nw-ai animate-pulse motion-reduce:animate-none"
+        :style="{ animationDelay: delay }"
+      />
+      <span
+        class="font-stamp uppercase tracking-[0.14em] text-[9px] text-nw-text-dim"
+      >
+        Processing…
+      </span>
+    </div>
+  </div>
+</template>

--- a/src/components/chat/Widget.vue
+++ b/src/components/chat/Widget.vue
@@ -1,0 +1,119 @@
+<script setup lang="ts">
+import { ref, watch, nextTick } from 'vue'
+import { useChatAssistant } from '@/composables/useChatAssistant'
+import { useFocusTrap } from '@/composables/useFocusTrap'
+
+const isOpen = ref(false)
+const panelRef = ref<HTMLElement | null>(null)
+const listRef = ref<HTMLElement | null>(null)
+
+const { messages, isLoading, cooldown, send } = useChatAssistant()
+
+useFocusTrap(panelRef, isOpen, () => (isOpen.value = false))
+
+function toggle() {
+  isOpen.value = !isOpen.value
+}
+
+function scrollToBottom() {
+  nextTick(() => {
+    if (listRef.value) listRef.value.scrollTop = listRef.value.scrollHeight
+  })
+}
+
+watch([() => messages.value.length, isLoading], scrollToBottom)
+watch(isOpen, (open) => open && scrollToBottom())
+</script>
+
+<template>
+  <div>
+    <!-- Launcher -->
+    <button
+      type="button"
+      :aria-label="isOpen ? 'Close assistant' : 'Ask the AI assistant about Carlos'"
+      :aria-expanded="isOpen"
+      class="fixed bottom-4 right-4 z-40 flex h-12 w-12 items-center justify-center rounded-full border transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-nw-primary"
+      :class="
+        isOpen
+          ? 'border-nw-ai-mute bg-void-panel text-nw-text-dim'
+          : 'border-nw-ai bg-nw-ai/10 text-nw-ai hover:shadow-[0_0_12px_rgba(178,102,224,0.35)]'
+      "
+      @click="toggle"
+    >
+      <LucideX v-if="isOpen" class="h-5 w-5" />
+      <LucideMessageSquare v-else class="h-5 w-5" />
+    </button>
+
+    <!-- Panel -->
+    <Transition
+      enter-active-class="transition duration-300 ease-out"
+      enter-from-class="opacity-0 translate-y-4"
+      leave-active-class="transition duration-200 ease-in"
+      leave-to-class="opacity-0 translate-y-4"
+    >
+      <div
+        v-if="isOpen"
+        ref="panelRef"
+        role="dialog"
+        aria-modal="true"
+        aria-label="AI assistant — ask about Carlos"
+        class="fixed inset-0 z-40 flex flex-col border-nw-ai-mute bg-void-warm sm:inset-auto sm:bottom-20 sm:right-4 sm:h-[560px] sm:max-h-[80vh] sm:w-[360px] sm:rounded-nw-sm sm:border"
+      >
+        <!-- Header -->
+        <header
+          class="flex items-center justify-between border-b border-nw-ai-mute px-3 py-2"
+        >
+          <span
+            class="flex items-center gap-2 font-stamp uppercase tracking-[0.14em] text-[10px] text-nw-ai"
+          >
+            <span class="led blue blink" />
+            AI DEBRIEF
+          </span>
+          <button
+            type="button"
+            aria-label="Close assistant"
+            class="text-nw-text-dim transition-colors hover:text-nw-text focus:outline-none focus-visible:ring-2 focus-visible:ring-nw-primary"
+            @click="isOpen = false"
+          >
+            <LucideX class="h-4 w-4" />
+          </button>
+        </header>
+
+        <!-- Messages -->
+        <div
+          ref="listRef"
+          class="flex-1 space-y-3 overflow-y-auto bg-void p-3"
+        >
+          <div
+            v-if="messages.length === 0"
+            class="flex h-full flex-col items-center justify-center gap-2 text-center"
+          >
+            <span class="led blue blink" />
+            <p
+              class="font-stamp uppercase tracking-[0.14em] text-[10px] text-nw-text-dim"
+            >
+              Ask anything about Carlos
+            </p>
+            <p class="font-sys text-xs text-nw-text-dim/70">
+              Experience · projects · stack · availability
+            </p>
+          </div>
+
+          <ChatMessage
+            v-for="(msg, i) in messages"
+            :key="i"
+            :message="msg"
+          />
+          <ChatTypingIndicator v-if="isLoading" />
+        </div>
+
+        <!-- Composer -->
+        <ChatComposer
+          :loading="isLoading"
+          :cooldown="cooldown"
+          @send="send"
+        />
+      </div>
+    </Transition>
+  </div>
+</template>

--- a/src/components/chat/Widget.vue
+++ b/src/components/chat/Widget.vue
@@ -32,6 +32,7 @@ watch(isOpen, (open) => open && scrollToBottom())
       type="button"
       :aria-label="isOpen ? 'Close assistant' : 'Ask the AI assistant about Carlos'"
       :aria-expanded="isOpen"
+      aria-controls="chat-panel"
       class="fixed bottom-4 right-4 z-40 flex h-12 w-12 items-center justify-center rounded-full border transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-nw-primary"
       :class="
         isOpen
@@ -53,6 +54,7 @@ watch(isOpen, (open) => open && scrollToBottom())
     >
       <div
         v-if="isOpen"
+        id="chat-panel"
         ref="panelRef"
         role="dialog"
         aria-modal="true"

--- a/src/composables/useChatAssistant.ts
+++ b/src/composables/useChatAssistant.ts
@@ -1,0 +1,76 @@
+import { ref, onScopeDispose } from 'vue'
+
+export interface ChatMessage {
+  role: 'user' | 'assistant' | 'error'
+  content: string
+  /** Distinguishes a generic error bubble from a rate-limit one. */
+  variant?: 'error' | 'rate-limit'
+}
+
+interface ChatApiResponse {
+  data: { answer: string; cached: boolean }
+}
+
+const RATE_LIMIT_COOLDOWN = 30
+
+export function useChatAssistant() {
+  const messages = ref<ChatMessage[]>([])
+  const isLoading = ref(false)
+  const cooldown = ref(0)
+
+  let timer: ReturnType<typeof setInterval> | null = null
+
+  function clearTimer() {
+    if (timer) {
+      clearInterval(timer)
+      timer = null
+    }
+  }
+
+  function startCooldown(seconds: number) {
+    cooldown.value = seconds
+    clearTimer()
+    timer = setInterval(() => {
+      cooldown.value -= 1
+      if (cooldown.value <= 0) clearTimer()
+    }, 1000)
+  }
+
+  async function send(text: string) {
+    const question = text.trim()
+    if (question.length < 1 || isLoading.value || cooldown.value > 0) return
+
+    messages.value.push({ role: 'user', content: question })
+    isLoading.value = true
+
+    try {
+      const res = await $fetch<ChatApiResponse>('/api/chat', {
+        method: 'POST',
+        body: { question },
+      })
+      messages.value.push({ role: 'assistant', content: res.data.answer })
+    } catch (err) {
+      const status = (err as { statusCode?: number })?.statusCode
+      if (status === 429) {
+        startCooldown(RATE_LIMIT_COOLDOWN)
+        messages.value.push({
+          role: 'error',
+          variant: 'rate-limit',
+          content: 'Too many questions — give it a moment and try again.',
+        })
+      } else {
+        messages.value.push({
+          role: 'error',
+          variant: 'error',
+          content: 'Something went wrong reaching the assistant. Please try again.',
+        })
+      }
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  onScopeDispose(clearTimer)
+
+  return { messages, isLoading, cooldown, send }
+}

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -5,6 +5,7 @@
       <slot />
     </main>
     <Footer />
+    <ChatWidget />
   </div>
 </template>
 

--- a/src/server/api/chat.post.ts
+++ b/src/server/api/chat.post.ts
@@ -1,0 +1,41 @@
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  const body = await readBody(event)
+
+  // Honeypot — reject if hidden 'website' field is filled
+  if (body.website && String(body.website).trim().length > 0) {
+    throw createError({ statusCode: 400, statusMessage: 'Bad Request' })
+  }
+
+  const question = typeof body.question === 'string' ? body.question.trim() : ''
+  if (question.length < 1) {
+    throw createError({ statusCode: 400, statusMessage: 'Question is required' })
+  }
+
+  try {
+    // /chat is a public endpoint — no API key is attached.
+    return await $fetch(`${config.apiBaseUrl}${config.apiBasePath}/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: { question: question.slice(0, 500) },
+    })
+  } catch (err) {
+    const status =
+      (err as { statusCode?: number; response?: { status?: number } })
+        ?.statusCode ||
+      (err as { response?: { status?: number } })?.response?.status ||
+      502
+
+    // Surface the meaningful states so the UI can react (rate limit, outage).
+    if (status === 429) {
+      throw createError({ statusCode: 429, statusMessage: 'Too Many Requests' })
+    }
+    if (status === 503) {
+      throw createError({
+        statusCode: 503,
+        statusMessage: 'Assistant temporarily unavailable',
+      })
+    }
+    throw createError({ statusCode: 502, statusMessage: 'Assistant error' })
+  }
+})

--- a/src/server/api/chat.post.ts
+++ b/src/server/api/chat.post.ts
@@ -2,6 +2,10 @@ export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
   const body = await readBody(event)
 
+  if (!body || typeof body !== 'object') {
+    throw createError({ statusCode: 400, statusMessage: 'Bad Request' })
+  }
+
   // Honeypot — reject if hidden 'website' field is filled
   if (body.website && String(body.website).trim().length > 0) {
     throw createError({ statusCode: 400, statusMessage: 'Bad Request' })


### PR DESCRIPTION
## Summary
A floating, **nightwire-styled** chat widget (site-wide via the default layout, public) that lets visitors ask questions about Carlos and get grounded answers from the backend assistant.

- **Proxy, not direct fetch:** a Nuxt server route `server/api/chat.post.ts` forwards to the backend `/chat` endpoint — keeps the call server-side and consistent with the existing `contacts` proxy. Honeypot + non-empty guard.
- **`useChatAssistant` composable:** message state, loading, and a 429 → rate-limit cooldown (30s countdown) mapping.
- **Components** (`components/chat/`): `Widget` (launcher + panel, focus-trap, Esc-to-close, mobile full-screen, auto-scroll), `Message` (user / assistant / error / rate-limit bubbles), `Composer` (Enter-to-send), `TypingIndicator`. Reuses `BaseButton` and the existing `useFocusTrap`.
- **nightwire tokens:** real registered tokens (`nw-ai` / `nw-ai-mute`, `nw-faint` / `nw-line`, `bg-*/10`).

## Depends on
Backend chat endpoint — `cativo23/portfolio-api` PR #124 (`POST /api/v1/chat`).

## Test plan
- [x] Full chain verified locally (Nuxt dev → proxy → API → Groq): grounded answers, incl. short greetings.
- [x] Rate-limit path confirmed (Groq 429 → backend 503 → UI surfaces it gracefully).
- [x] Visual QA: nightwire styling correct, open/close, conversation persists, mobile full-screen.
- [x] Approved by Carlos in-browser.