### PR TITLE
ci(deploy): sync Spotify credentials from CI secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,9 +84,21 @@ jobs:
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           port: ${{ secrets.SSH_PORT }}
-          envs: DOCKER_USERNAME,DOCKER_PASSWORD,POW_GH_TOKEN
+          envs: DOCKER_USERNAME,DOCKER_PASSWORD,POW_GH_TOKEN,SPOTIFY_CLIENT_ID,SPOTIFY_CLIENT_SECRET,SPOTIFY_REFRESH_TOKEN
           script: |
             cd /home/cativo23/deploy/portfolio-deploy
+
+            # Sync Spotify credentials from CI secrets into .env (idempotent upsert)
+            touch .env
+            for kv in \
+              "NUXT_SPOTIFY_CLIENT_ID=${SPOTIFY_CLIENT_ID}" \
+              "NUXT_SPOTIFY_CLIENT_SECRET=${SPOTIFY_CLIENT_SECRET}" \
+              "NUXT_SPOTIFY_REFRESH_TOKEN=${SPOTIFY_REFRESH_TOKEN}"; do
+              key="${kv%%=*}"
+              grep -v "^${key}=" .env > .env.tmp || true
+              echo "$kv" >> .env.tmp
+              mv .env.tmp .env
+            done
 
             # Login to Docker Hub on server
             echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin


### PR DESCRIPTION
## Summary
- Forward `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, `SPOTIFY_REFRESH_TOKEN` over SSH (`envs:`) — they were defined in the job `env:` but never passed to the remote script.
- Upsert the matching `NUXT_SPOTIFY_*` keys into the server `.env` idempotently before `docker compose up`, so the deploy owns the credentials instead of requiring a manual edit on the host.

## Context
The Spotify refresh token gets revoked periodically. Until now the fix was a manual edit of `/home/cativo23/deploy/portfolio-deploy/.env` on polaris2. With this change, rotating the token only means updating the `SPOTIFY_REFRESH_TOKEN` GitHub secret (already done with the fresh token) and redeploying.

## Notes
- No image rebuild needed for token rotation — `NUXT_SPOTIFY_*` is server-side `runtimeConfig`, read at runtime from env, not baked at build time.
- The upsert strips any existing `NUXT_SPOTIFY_*` line before appending, so it won't duplicate on repeat deploys and leaves all other `.env` keys untouched.

## Test plan
- [ ] Trigger a prod deploy (release) and confirm the workflow writes the three keys to the server `.env`.
- [ ] `curl https://cativo.dev/api/spotify/now-playing` returns `isPlaying`/track data.