### PR TITLE
Release 1.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.1] - 2026-06-03
+
+### Security
+- **Content Security Policy is now enforced** (flipped out of report-only). A full-site browser audit — every page, all project detail pages, and the chat widget — cross-checked against the `/api/csp-report` logs found zero script/style/connect violations; `script-src`/`style-src` remain strict (nonce + `strict-dynamic`). `img-src` is set to `'self' data: https:` so project markdown (README-style badges and screenshots from arbitrary hosts) and Spotify album art render without breaking, while keeping the directives that actually matter for XSS strict. The `report-uri` sink stays wired so enforced violations are still logged. (#123 follow-up)
+
+---
+
 ## [1.12.0] - 2026-06-03
 
 ### Added

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -84,9 +84,12 @@ export default defineNuxtConfig({
     provider: 'ipx',
   },
   security: {
-    // Phase 1: report-only. The browser reports violations to /api/csp-report
-    // but nothing is blocked. Flip to `false` to enforce once reports are clean.
-    contentSecurityPolicyReportOnly: true,
+    // Enforced. A full-site browser audit (every page + all project detail pages +
+    // the chat widget), cross-checked against /api/csp-report logs, found zero
+    // script/style/connect violations — only images from external hosts (Spotify
+    // album art, README badges in project markdown). img-src is permissive (https:)
+    // below to cover those; report-uri stays wired so enforced violations are logged.
+    contentSecurityPolicyReportOnly: false,
     headers: {
       contentSecurityPolicy: {
         // Strict scripts: nonce + strict-dynamic only (no 'unsafe-inline'/'https:').
@@ -100,7 +103,11 @@ export default defineNuxtConfig({
         'font-src': ["'self'", 'https://fonts.gstatic.com'],
         // Client only ever calls its own /api/* BFF routes.
         'connect-src': ["'self'"],
-        'img-src': ["'self'", 'data:'],
+        // Permissive for images only: project markdown (README-style) embeds
+        // badges/screenshots from arbitrary hosts (img.shields.io, Spotify's
+        // i.scdn.co, future CDNs). Images can't execute code, so `https:` here
+        // is low-risk while script-src/style-src stay strict (nonce+strict-dynamic).
+        'img-src': ["'self'", 'data:', 'https:'],
         'report-uri': ['/api/csp-report'],
       },
       // COEP would block the cross-origin Google Fonts; not needed for this site.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-app",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Content Security Policy is now enforced in production. A full-site audit against CSP violation logs found no violations; `script-src`/`style-src` remain strict (nonce + strict-dynamic), while `img-src` is set to allow project markdown badges and Spotify album art from arbitrary HTTPS hosts. The report-uri sink stays wired to surface any real-world violations.

## Highlights

- **Content Security Policy is now enforced** (flipped out of report-only). A full-site browser audit — every page, all project detail pages, and the chat widget — cross-checked against the `/api/csp-report` logs found zero script/style/connect violations; `script-src`/`style-src` remain strict (nonce + `strict-dynamic`). `img-src` is set to `'self' data: https:` so project markdown (README-style badges and screenshots from arbitrary hosts) and Spotify album art render without breaking, while keeping the directives that actually matter for XSS strict. The `report-uri` sink stays wired so enforced violations are still logged. (#123 follow-up)

## Test plan

- [x] CI `build` green on source PRs
- [ ] Post-merge: auto-release tags `v1.12.1` and publishes GitHub Release
- [ ] Post-merge: Deploy workflow succeeds on polaris2
- [ ] Post-deploy: `curl -I https://cativo.dev/` shows enforced Content-Security-Policy header (not -Report-Only)
- [ ] Post-deploy: container reports `healthy`
- [ ] Post-release: `main` merged back to `develop`

Refs #123