### PR TITLE
fix(footer): resolve NowPlayingBars by importing it explicitly

### DIFF
--- a/src/components/main/Footer.vue
+++ b/src/components/main/Footer.vue
@@ -67,6 +67,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue';
+import NowPlayingBars from '~/components/ui/NowPlayingBars.vue';
 
 const { nowPlaying } = useNowPlaying();
 

--- a/src/pages/now.vue
+++ b/src/pages/now.vue
@@ -209,6 +209,8 @@
 </template>
 
 <script setup lang="ts">
+import NowPlayingBars from '~/components/ui/NowPlayingBars.vue';
+
 const lastUpdated = '2026-05-21';
 
 const { nowPlaying } = useNowPlaying();


### PR DESCRIPTION
## Bug
`Footer.vue` and `now.vue` used `<NowPlayingBars />` **without importing it**, relying on Nuxt auto-import. The component lives in `components/ui/`, so Nuxt registers it as `<UiNowPlayingBars>` (directory-prefixed). The bare name never resolved → Vue left a literal `<nowplayingbars>` element in the DOM and the equalizer bars never rendered (plus a console resolve-warning).

## Fix
Import it explicitly from `~/components/ui/NowPlayingBars.vue` in both files, matching the convention already used for the other `ui/` components (`health.vue`, `HealthBadge.vue` both import `StatusIndicator`/`MetaInfoPair` explicitly). Template usage (`<NowPlayingBars />`) stays unchanged.

## Verification
Reproduced live (prod /now had **2** unresolved `<nowplayingbars>` elements). After the fix, validated in local dev (`docker compose up`) with a real playing track:
- `renderedBarsComponents: 2` (now.vue + footer) → both resolve and render
- each renders `.now-playing-bars` with its 3 animated `<span>` bars
- `unresolvedLiteralEls: 0`

Files: `src/components/main/Footer.vue`, `src/pages/now.vue` (2 import lines). No other changes.