### PR TITLE
Release 1.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.2] - 2026-06-04
+
+### Fixed
+- **Now-playing equalizer bars render again** — `Footer.vue` and the `/now` page used `<NowPlayingBars />` without importing it. The component lives in `components/ui/`, so Nuxt only registered it under the directory-prefixed auto-import name; the bare tag never resolved, leaving a literal element in the DOM and the animated bars missing. Imported explicitly from `~/components/ui/NowPlayingBars.vue`. (#126)
+
+---
+
 ## [1.12.1] - 2026-06-03
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-app",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/components/main/Footer.vue
+++ b/src/components/main/Footer.vue
@@ -67,6 +67,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue';
+import NowPlayingBars from '~/components/ui/NowPlayingBars.vue';
 
 const { nowPlaying } = useNowPlaying();
 

--- a/src/pages/now.vue
+++ b/src/pages/now.vue
@@ -209,6 +209,8 @@
 </template>
 
 <script setup lang="ts">
+import NowPlayingBars from '~/components/ui/NowPlayingBars.vue';
+
 const lastUpdated = '2026-05-21';
 
 const { nowPlaying } = useNowPlaying();


### PR DESCRIPTION
## Summary

Fixed the now-playing equalizer bars component that was failing to render in Footer and /now page due to missing explicit import. The component was previously relying on Nuxt auto-import but the bare tag name never resolved.

## Highlights

- **Now-playing equalizer bars render again** — `Footer.vue` and the `/now` page used `<NowPlayingBars />` without importing it. The component lives in `components/ui/`, so Nuxt only registered it under the directory-prefixed auto-import name; the bare tag never resolved, leaving a literal element in the DOM and the animated bars missing. Imported explicitly from `~/components/ui/NowPlayingBars.vue`. (#126)

## Test plan

- [x] CI `build` green on source PRs
- [ ] Post-merge: auto-release tags `v1.12.2` and publishes GitHub Release
- [ ] Post-merge: Deploy workflow succeeds on polaris2
- [ ] Post-deploy: `curl -I https://cativo.dev/` shows 200 and includes enforced `Content-Security-Policy` header
- [ ] Post-deploy: container reports healthy
- [ ] Post-release: `main` merged back to `develop`

Refs #126