### PR TITLE
Ship multi-turn chat and solid launcher button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.0] - 2026-06-04
+
+### Added
+- **Multi-turn chat** — the assistant widget now replays the last 6 conversation turns with each question, so follow-ups that rely on earlier context resolve correctly. The conversation lives for the page session (a refresh starts fresh).
+
+### Changed
+- **Solid chat launcher button** — the floating assistant button now uses a solid accent fill instead of a 10%-opacity tint, making it clearly visible on the dark background.
+
+---
+
 ## [1.12.3] - 2026-06-04
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-app",
-  "version": "1.12.3",
+  "version": "1.13.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/components/chat/Widget.vue
+++ b/src/components/chat/Widget.vue
@@ -37,7 +37,7 @@ watch(isOpen, (open) => open && scrollToBottom())
       :class="
         isOpen
           ? 'border-nw-ai-mute bg-void-panel text-nw-text-dim'
-          : 'border-nw-ai bg-nw-ai/10 text-nw-ai hover:shadow-[0_0_12px_rgba(178,102,224,0.35)]'
+          : 'border-nw-ai bg-nw-ai text-void hover:bg-nw-ai/90 hover:shadow-[0_0_16px_rgba(178,102,224,0.5)]'
       "
       @click="toggle"
     >

--- a/src/composables/useChatAssistant.ts
+++ b/src/composables/useChatAssistant.ts
@@ -40,13 +40,20 @@ export function useChatAssistant() {
     const question = text.trim()
     if (question.length < 1 || isLoading.value || cooldown.value > 0) return
 
+    // Replay recent turns for context — the server is stateless. Exclude error
+    // bubbles (not real turns) and cap to the last 6 (matches the API limit).
+    const history = messages.value
+      .filter((m) => m.role === 'user' || m.role === 'assistant')
+      .slice(-6)
+      .map((m) => ({ role: m.role, content: m.content }))
+
     messages.value.push({ role: 'user', content: question })
     isLoading.value = true
 
     try {
       const res = await $fetch<ChatApiResponse>('/api/chat', {
         method: 'POST',
-        body: { question },
+        body: { question, history },
       })
       messages.value.push({ role: 'assistant', content: res.data.answer })
     } catch (err) {

--- a/src/server/api/chat.post.ts
+++ b/src/server/api/chat.post.ts
@@ -33,7 +33,7 @@ export default defineEventHandler(async (event) => {
         typeof (m as { content?: unknown }).content === 'string',
     )
     .slice(-6)
-    .map((m) => ({ role: m.role, content: m.content.slice(0, 2000) }))
+    .map((m: { role: string; content: string }) => ({ role: m.role, content: m.content.slice(0, 2000) }))
 
   try {
     // /chat is a public endpoint — no API key is attached.

--- a/src/server/api/chat.post.ts
+++ b/src/server/api/chat.post.ts
@@ -16,12 +16,31 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'Question is required' })
   }
 
+  // Multi-turn context: keep only well-formed user/assistant turns, cap content
+  // length and turn count to the API's limits. The backend re-validates and
+  // sanitizes, so this is just to avoid forwarding obvious junk.
+  // Bound the array length BEFORE iterating, so a client can't force a large
+  // filter pass with a giant array (the backend's ArrayMaxSize is a separate
+  // validation layer, not an upstream size guard). Keep the most recent.
+  const rawHistory = (Array.isArray(body.history) ? body.history : []).slice(-20)
+  const history = rawHistory
+    .filter(
+      (m: unknown): m is { role: string; content: string } =>
+        !!m &&
+        typeof m === 'object' &&
+        ((m as { role?: unknown }).role === 'user' ||
+          (m as { role?: unknown }).role === 'assistant') &&
+        typeof (m as { content?: unknown }).content === 'string',
+    )
+    .slice(-6)
+    .map((m) => ({ role: m.role, content: m.content.slice(0, 2000) }))
+
   try {
     // /chat is a public endpoint — no API key is attached.
     return await $fetch(`${config.apiBaseUrl}${config.apiBasePath}/chat`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: { question: question.slice(0, 500) },
+      body: { question: question.slice(0, 500), history },
     })
   } catch (err) {
     const status =


### PR DESCRIPTION
## Summary

The assistant widget now replays the last 6 conversation turns with each question, enabling follow-ups that rely on earlier context to resolve correctly. The conversation persists for the page session. The floating launcher button now uses a solid accent fill for better visibility on the dark background.

## Highlights

- **Multi-turn chat** — the assistant widget now replays the last 6 conversation turns with each question, so follow-ups that rely on earlier context resolve correctly. The conversation lives for the page session (a refresh starts fresh).
- **Solid chat launcher button** — the floating assistant button now uses a solid accent fill instead of a 10%-opacity tint, making it clearly visible on the dark background.

## Test plan

- [x] CI `build` green on source PRs
- [ ] Post-merge: auto-release tags `v1.13.0` and publishes GitHub Release
- [ ] Post-merge: Deploy workflow succeeds on polaris2
- [ ] Post-deploy: `curl -I https://cativo.dev/` shows expected headers
- [ ] Post-deploy: container reports `healthy`
- [ ] Post-release: `main` merged back to `develop`