### PR TITLE
feat: forward real client IP from BFF to backend

### DIFF
--- a/src/server/api/admin/contacts.get.ts
+++ b/src/server/api/admin/contacts.get.ts
@@ -1,9 +1,10 @@
+import { apiFetch } from '~/server/utils/api'
+
 export default defineEventHandler(async (event) => {
-  const config = useRuntimeConfig()
   const query = getQuery(event)
   const cookie = getCookie(event, 'admin_token')
 
-  return $fetch(`${config.apiBaseUrl}${config.apiBasePath}/contacts`, {
+  return apiFetch(event, `/contacts`, {
     method: 'GET',
     headers: { Authorization: `Bearer ${cookie ?? ''}` },
     query,

--- a/src/server/api/admin/contacts/[id].delete.ts
+++ b/src/server/api/admin/contacts/[id].delete.ts
@@ -1,11 +1,12 @@
+import { apiFetch } from '~/server/utils/api'
+
 export default defineEventHandler(async (event) => {
-  const config = useRuntimeConfig()
   const id = getRouterParam(event, 'id')
 
   if (!id) throw createError({ statusCode: 400, statusMessage: 'Missing contact ID' })
   const cookie = getCookie(event, 'admin_token')
 
-  return $fetch(`${config.apiBaseUrl}${config.apiBasePath}/contacts/${id}`, {
+  return apiFetch(event, `/contacts/${id}`, {
     method: 'DELETE',
     headers: { Authorization: `Bearer ${cookie ?? ''}` },
   })

--- a/src/server/api/admin/login.post.ts
+++ b/src/server/api/admin/login.post.ts
@@ -1,5 +1,6 @@
+import { apiFetch } from '~/server/utils/api'
+
 export default defineEventHandler(async (event) => {
-  const config = useRuntimeConfig()
   const body = await readBody<{ email: string; password: string }>(event)
 
   if (!body.email || !body.password) {
@@ -24,7 +25,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const data: Record<string, any> = await $fetch(`${config.apiBaseUrl}${config.apiBasePath}/auth/login`, {
+  const data: Record<string, any> = await apiFetch(event, `/auth/login`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: { email: trimmedEmail, password: body.password },

--- a/src/server/api/admin/me.get.ts
+++ b/src/server/api/admin/me.get.ts
@@ -1,5 +1,6 @@
+import { apiFetch } from '~/server/utils/api'
+
 export default defineEventHandler(async (event) => {
-  const config = useRuntimeConfig()
   const cookie = getCookie(event, 'admin_token')
 
   if (!cookie) {
@@ -11,7 +12,7 @@ export default defineEventHandler(async (event) => {
     Authorization: `Bearer ${cookie}`,
   }
 
-  return $fetch(`${config.apiBaseUrl}${config.apiBasePath}/auth/profile`, {
+  return apiFetch(event, `/auth/profile`, {
     method: 'GET',
     headers,
   })

--- a/src/server/api/admin/projects.get.ts
+++ b/src/server/api/admin/projects.get.ts
@@ -1,5 +1,6 @@
+import { apiFetch } from '~/server/utils/api'
+
 export default defineEventHandler(async (event) => {
-  const config = useRuntimeConfig()
   const query = getQuery(event)
   const cookie = getCookie(event, 'admin_token')
 
@@ -8,7 +9,7 @@ export default defineEventHandler(async (event) => {
     headers.Authorization = `Bearer ${cookie}`
   }
 
-  return $fetch(`${config.apiBaseUrl}${config.apiBasePath}/projects`, {
+  return apiFetch(event, `/projects`, {
     method: 'GET',
     headers,
     query,

--- a/src/server/api/admin/projects/[id].get.ts
+++ b/src/server/api/admin/projects/[id].get.ts
@@ -1,5 +1,6 @@
+import { apiFetch } from '~/server/utils/api'
+
 export default defineEventHandler(async (event) => {
-  const config = useRuntimeConfig()
   const id = getRouterParam(event, 'id')
   const cookie = getCookie(event, 'admin_token')
 
@@ -8,7 +9,7 @@ export default defineEventHandler(async (event) => {
     headers.Authorization = `Bearer ${cookie}`
   }
 
-  return $fetch(`${config.apiBaseUrl}${config.apiBasePath}/projects/${id}`, {
+  return apiFetch(event, `/projects/${id}`, {
     method: 'GET',
     headers,
   })

--- a/src/server/api/admin/users/[id].delete.ts
+++ b/src/server/api/admin/users/[id].delete.ts
@@ -1,5 +1,6 @@
+import { apiFetch } from '~/server/utils/api'
+
 export default defineEventHandler(async (event) => {
-  const config = useRuntimeConfig()
   const cookie = getCookie(event, 'admin_token')
   const id = getRouterParam(event, 'id')
 
@@ -8,7 +9,7 @@ export default defineEventHandler(async (event) => {
   const headers: Record<string, string> = {}
   if (cookie) headers.Authorization = `Bearer ${cookie}`
 
-  return $fetch(`${config.apiBaseUrl}${config.apiBasePath}/admin/users/${id}`, {
+  return apiFetch(event, `/admin/users/${id}`, {
     method: 'DELETE',
     headers,
   })

--- a/src/server/api/admin/users/[id].put.ts
+++ b/src/server/api/admin/users/[id].put.ts
@@ -1,5 +1,6 @@
+import { apiFetch } from '~/server/utils/api'
+
 export default defineEventHandler(async (event) => {
-  const config = useRuntimeConfig()
   const cookie = getCookie(event, 'admin_token')
   const id = getRouterParam(event, 'id')
   const body = await readBody(event)
@@ -9,7 +10,7 @@ export default defineEventHandler(async (event) => {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
   if (cookie) headers.Authorization = `Bearer ${cookie}`
 
-  return $fetch(`${config.apiBaseUrl}${config.apiBasePath}/admin/users/${id}`, {
+  return apiFetch(event, `/admin/users/${id}`, {
     method: 'PUT',
     headers,
     body,

--- a/src/server/api/admin/users/index.get.ts
+++ b/src/server/api/admin/users/index.get.ts
@@ -1,5 +1,6 @@
+import { apiFetch } from '~/server/utils/api'
+
 export default defineEventHandler(async (event) => {
-  const config = useRuntimeConfig()
   const cookie = getCookie(event, 'admin_token')
 
   const headers: Record<string, string> = {}
@@ -7,7 +8,7 @@ export default defineEventHandler(async (event) => {
     headers.Authorization = `Bearer ${cookie}`
   }
 
-  return $fetch(`${config.apiBaseUrl}${config.apiBasePath}/admin/users`, {
+  return apiFetch(event, `/admin/users`, {
     method: 'GET',
     headers,
   })

--- a/src/server/api/admin/users/index.post.ts
+++ b/src/server/api/admin/users/index.post.ts
@@ -1,7 +1,8 @@
+import { apiFetch } from '~/server/utils/api'
+
 // User management proxy — auth is enforced by server middleware on all /api/admin/* routes.
 // The upstream API should enforce role-level checks (e.g., super-admin) for user management.
 export default defineEventHandler(async (event) => {
-  const config = useRuntimeConfig()
   const body = await readBody(event)
 
   // Forward the httpOnly cookie as Bearer token for upstream validation
@@ -9,7 +10,7 @@ export default defineEventHandler(async (event) => {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
   if (cookie) headers.Authorization = `Bearer ${cookie}`
 
-  return $fetch(`${config.apiBaseUrl}${config.apiBasePath}/admin/users`, {
+  return apiFetch(event, `/admin/users`, {
     method: 'POST',
     headers,
     body,

--- a/src/server/api/chat.post.ts
+++ b/src/server/api/chat.post.ts
@@ -1,5 +1,6 @@
+import { apiFetch } from '~/server/utils/api'
+
 export default defineEventHandler(async (event) => {
-  const config = useRuntimeConfig()
   const body = await readBody(event)
 
   if (!body || typeof body !== 'object') {
@@ -37,7 +38,7 @@ export default defineEventHandler(async (event) => {
 
   try {
     // /chat is a public endpoint — no API key is attached.
-    return await $fetch(`${config.apiBaseUrl}${config.apiBasePath}/chat`, {
+    return await apiFetch(event, `/chat`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: { question: question.slice(0, 500), history },

--- a/src/server/api/contacts.post.ts
+++ b/src/server/api/contacts.post.ts
@@ -1,3 +1,5 @@
+import { apiFetch } from '~/server/utils/api'
+
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
   const body = await readBody(event)
@@ -25,7 +27,7 @@ export default defineEventHandler(async (event) => {
     headers.Authorization = `ApiKey ${config.apiToken}`
   }
 
-  const data = await $fetch(`${config.apiBaseUrl}${config.apiBasePath}/contacts`, {
+  const data = await apiFetch(event, `/contacts`, {
     method: 'POST',
     headers,
     body: {

--- a/src/server/api/health.get.ts
+++ b/src/server/api/health.get.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from '~/server/utils/api'
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
@@ -15,10 +16,10 @@ export default defineEventHandler(async (event) => {
     headers['x-api-key'] = config.apiToken
   }
 
-  const endpoint = `${config.apiBaseUrl}/health${type !== 'basic' ? `/${type}` : ''}`
+  const endpoint = `/health${type !== 'basic' ? `/${type}` : ''}`
 
   try {
-    const health = await $fetch<{
+    const health = await apiFetch<{
       status: string
       data: {
         status: string
@@ -36,9 +37,10 @@ export default defineEventHandler(async (event) => {
         }
       }
       request_id?: string
-    }>(endpoint, {
+    }>(event, endpoint, {
       method: 'GET',
       headers,
+      basePath: false,
     })
 
     return {

--- a/src/server/api/health/detailed.get.ts
+++ b/src/server/api/health/detailed.get.ts
@@ -1,4 +1,6 @@
-export default defineEventHandler(async () => {
+import { apiFetch } from '~/server/utils/api'
+
+export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
 
   const headers: Record<string, string> = {}
@@ -7,7 +9,7 @@ export default defineEventHandler(async () => {
   }
 
   try {
-    const health = await $fetch<{
+    const health = await apiFetch<{
       status: string
       data: {
         status: string
@@ -32,9 +34,10 @@ export default defineEventHandler(async () => {
         }>
       }
       request_id?: string
-    }>(`${config.apiBaseUrl}/health/detailed`, {
+    }>(event, `/health/detailed`, {
       method: 'GET',
       headers,
+      basePath: false,
     })
 
     return {

--- a/src/server/api/health/live.get.ts
+++ b/src/server/api/health/live.get.ts
@@ -1,4 +1,6 @@
-export default defineEventHandler(async () => {
+import { apiFetch } from '~/server/utils/api'
+
+export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
 
   const headers: Record<string, string> = {}
@@ -7,7 +9,7 @@ export default defineEventHandler(async () => {
   }
 
   try {
-    const health = await $fetch<{
+    const health = await apiFetch<{
       status: string
       data: {
         status: string
@@ -16,9 +18,10 @@ export default defineEventHandler(async () => {
         details: Record<string, { status: string }>
       }
       request_id?: string
-    }>(`${config.apiBaseUrl}/health/live`, {
+    }>(event, `/health/live`, {
       method: 'GET',
       headers,
+      basePath: false,
     })
 
     return {

--- a/src/server/api/health/ready.get.ts
+++ b/src/server/api/health/ready.get.ts
@@ -1,4 +1,6 @@
-export default defineEventHandler(async () => {
+import { apiFetch } from '~/server/utils/api'
+
+export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
 
   const headers: Record<string, string> = {}
@@ -7,7 +9,7 @@ export default defineEventHandler(async () => {
   }
 
   try {
-    const health = await $fetch<{
+    const health = await apiFetch<{
       status: string
       data: {
         status: string
@@ -16,9 +18,10 @@ export default defineEventHandler(async () => {
         details: Record<string, { status: string }>
       }
       request_id?: string
-    }>(`${config.apiBaseUrl}/health/ready`, {
+    }>(event, `/health/ready`, {
       method: 'GET',
       headers,
+      basePath: false,
     })
 
     return {

--- a/src/server/api/index.get.ts
+++ b/src/server/api/index.get.ts
@@ -1,9 +1,10 @@
-export default defineEventHandler(async () => {
-  const config = useRuntimeConfig()
+import { apiFetch } from '~/server/utils/api'
 
+export default defineEventHandler(async (event) => {
   try {
-    const info = await $fetch<{ status: string; data: { name: string; version: string; description: string; environment: string; documentation: string; health: string; status: string; timestamp: string } }>(`${config.apiBaseUrl}/`, {
+    const info = await apiFetch<{ status: string; data: { name: string; version: string; description: string; environment: string; documentation: string; health: string; status: string; timestamp: string } }>(event, `/`, {
       method: 'GET',
+      basePath: false,
     })
 
     return {

--- a/src/server/api/profile.get.ts
+++ b/src/server/api/profile.get.ts
@@ -1,4 +1,6 @@
-export default defineEventHandler(async () => {
+import { apiFetch } from '~/server/utils/api'
+
+export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig();
 
   const headers: Record<string, string> = {
@@ -9,7 +11,7 @@ export default defineEventHandler(async () => {
   }
 
   try {
-    const data = await $fetch(`${config.apiBaseUrl}${config.apiBasePath}/profile`, {
+    const data = await apiFetch(event, `/profile`, {
       method: 'GET',
       headers,
     });

--- a/src/server/api/projects.get.ts
+++ b/src/server/api/projects.get.ts
@@ -1,3 +1,5 @@
+import { apiFetch } from '~/server/utils/api'
+
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
   const query = getQuery(event)
@@ -7,7 +9,7 @@ export default defineEventHandler(async (event) => {
     headers['x-api-key'] = config.apiToken
   }
 
-  const data = await $fetch<{ data?: Array<Record<string, unknown>>; [key: string]: unknown }>(`${config.apiBaseUrl}${config.apiBasePath}/projects`, {
+  const data = await apiFetch<{ data?: Array<Record<string, unknown>>; [key: string]: unknown }>(event, `/projects`, {
     method: 'GET',
     headers,
     query,

--- a/src/server/api/projects.post.ts
+++ b/src/server/api/projects.post.ts
@@ -1,10 +1,11 @@
+import { apiFetch } from '~/server/utils/api'
+
 export default defineEventHandler(async (event) => {
-  const config = useRuntimeConfig()
   const cookie = getCookie(event, 'admin_token')
 
   const body = await readBody(event)
 
-  return $fetch(`${config.apiBaseUrl}${config.apiBasePath}/projects`, {
+  return apiFetch(event, `/projects`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${cookie ?? ''}` },
     body,

--- a/src/server/api/projects/[id].delete.ts
+++ b/src/server/api/projects/[id].delete.ts
@@ -1,5 +1,6 @@
+import { apiFetch } from '~/server/utils/api'
+
 export default defineEventHandler(async (event) => {
-  const config = useRuntimeConfig()
   const id = getRouterParam(event, 'id')
   const cookie = getCookie(event, 'admin_token')
 
@@ -7,7 +8,7 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'Missing project ID' })
   }
 
-  return $fetch(`${config.apiBaseUrl}${config.apiBasePath}/projects/${id}`, {
+  return apiFetch(event, `/projects/${id}`, {
     method: 'DELETE',
     headers: { Authorization: `Bearer ${cookie ?? ''}` },
   })

--- a/src/server/api/projects/[id].get.ts
+++ b/src/server/api/projects/[id].get.ts
@@ -1,3 +1,5 @@
+import { apiFetch } from '~/server/utils/api'
+
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
   const { id } = getRouterParams(event)
@@ -7,7 +9,7 @@ export default defineEventHandler(async (event) => {
     headers['x-api-key'] = config.apiToken
   }
 
-  const data = await $fetch<{ status?: string; data?: Record<string, unknown> }>(`${config.apiBaseUrl}${config.apiBasePath}/projects/${id}`, {
+  const data = await apiFetch<{ status?: string; data?: Record<string, unknown> }>(event, `/projects/${id}`, {
     method: 'GET',
     headers,
   })

--- a/src/server/api/projects/[id].patch.ts
+++ b/src/server/api/projects/[id].patch.ts
@@ -1,11 +1,12 @@
+import { apiFetch } from '~/server/utils/api'
+
 export default defineEventHandler(async (event) => {
-  const config = useRuntimeConfig()
   const id = getRouterParam(event, 'id')
   const cookie = getCookie(event, 'admin_token')
 
   const body = await readBody(event)
 
-  return $fetch(`${config.apiBaseUrl}${config.apiBasePath}/projects/${id}`, {
+  return apiFetch(event, `/projects/${id}`, {
     method: 'PATCH',
     headers: { Authorization: `Bearer ${cookie ?? ''}` },
     body,

--- a/src/server/utils/api.ts
+++ b/src/server/utils/api.ts
@@ -1,0 +1,36 @@
+import type { H3Event } from 'h3'
+
+type ApiFetchOptions = NonNullable<Parameters<typeof $fetch>[1]> & {
+  /**
+   * Prepend the versioned API base path (`config.apiBasePath`, e.g. `/api/v1`).
+   * Defaults to `true`; pass `false` for unversioned endpoints such as `/` and
+   * `/health`.
+   */
+  basePath?: boolean
+}
+
+/**
+ * Centralized fetch for every BFF → backend API call.
+ *
+ * Composes the upstream URL from runtime config (`apiBaseUrl` + optional
+ * `apiBasePath`) so the base location lives in exactly one place instead of
+ * being duplicated across every server route.
+ *
+ * Accepts the request `event` so the real client IP can be forwarded to the
+ * backend (wired up separately) — without it, every visitor's request reaches
+ * the API from the BFF container's IP and the backend's per-IP rate limit
+ * collapses into a single shared bucket.
+ */
+export function apiFetch<T = unknown>(
+  _event: H3Event,
+  path: string,
+  opts: ApiFetchOptions = {},
+) {
+  const config = useRuntimeConfig()
+  const { basePath = true, headers, ...rest } = opts
+  const base = basePath
+    ? `${config.apiBaseUrl}${config.apiBasePath}`
+    : config.apiBaseUrl
+
+  return $fetch<T>(`${base}${path}`, { ...rest, headers })
+}

--- a/src/server/utils/api.ts
+++ b/src/server/utils/api.ts
@@ -16,21 +16,35 @@ type ApiFetchOptions = NonNullable<Parameters<typeof $fetch>[1]> & {
  * `apiBasePath`) so the base location lives in exactly one place instead of
  * being duplicated across every server route.
  *
- * Accepts the request `event` so the real client IP can be forwarded to the
- * backend (wired up separately) — without it, every visitor's request reaches
- * the API from the BFF container's IP and the backend's per-IP rate limit
- * collapses into a single shared bucket.
+ * Forwards the real client IP to the backend so its per-IP rate limit keys on
+ * the visitor instead of this BFF container's IP — without it every visitor's
+ * request reaches the API from one address and the throttle collapses into a
+ * single shared bucket.
  */
 export function apiFetch<T = unknown>(
-  _event: H3Event,
+  event: H3Event,
   path: string,
   opts: ApiFetchOptions = {},
-) {
+): Promise<T> {
   const config = useRuntimeConfig()
   const { basePath = true, headers, ...rest } = opts
   const base = basePath
     ? `${config.apiBaseUrl}${config.apiBasePath}`
     : config.apiBaseUrl
 
-  return $fetch<T>(`${base}${path}`, { ...rest, headers })
+  // getRequestIP returns the leftmost X-Forwarded-For entry, which is the true
+  // client ONLY because the edge proxy (Traefik) strips client-supplied XFF and
+  // rewrites it with the real connection IP. The BFF→API hop is internal and
+  // bypasses Traefik, so this single clean value is what the backend reads
+  // (trust proxy = 1 hop). LOAD-BEARING: do not enable forwardedHeaders/insecure
+  // on the Traefik edge without re-checking this — it would make XFF spoofable.
+  const clientIp = getRequestIP(event, { xForwardedFor: true })
+  const mergedHeaders: Record<string, string> = {
+    ...(headers as Record<string, string> | undefined),
+    ...(clientIp ? { 'x-forwarded-for': clientIp } : {}),
+  }
+
+  // $fetch in the Nitro server context returns Nitro's TypedInternalResponse
+  // wrapper; for our external JSON calls that resolves to T at runtime.
+  return $fetch<T>(`${base}${path}`, { ...rest, headers: mergedHeaders }) as Promise<T>
 }

--- a/tests/server/api/admin/contacts.get.test.ts
+++ b/tests/server/api/admin/contacts.get.test.ts
@@ -15,6 +15,7 @@ vi.stubGlobal('createError', vi.fn((opts: any) => {
   return err
 }))
 vi.stubGlobal('defineEventHandler', vi.fn((handler: Function) => handler))
+vi.stubGlobal('getRequestIP', () => undefined) // client-IP forwarding is covered in tests/server/utils/api.test.ts
 vi.stubGlobal('$fetch', vi.fn(() => Promise.resolve({ data: [] })))
 
 // ---------- Import handler after stubs are set up ----------

--- a/tests/server/api/admin/login.post.test.ts
+++ b/tests/server/api/admin/login.post.test.ts
@@ -15,6 +15,7 @@ vi.stubGlobal('createError', vi.fn((opts: any) => {
   return err
 }))
 vi.stubGlobal('defineEventHandler', vi.fn((handler: Function) => handler))
+vi.stubGlobal('getRequestIP', () => undefined) // client-IP forwarding is covered in tests/server/utils/api.test.ts
 vi.stubGlobal('$fetch', vi.fn(() => Promise.resolve({})))
 
 // ---------- Import handler after stubs are set up ----------

--- a/tests/server/api/admin/me.get.test.ts
+++ b/tests/server/api/admin/me.get.test.ts
@@ -15,6 +15,7 @@ vi.stubGlobal('createError', mockCreateError)
 const mockFetch = vi.fn()
 vi.stubGlobal('$fetch', mockFetch)
 vi.stubGlobal('defineEventHandler', (handler: any) => handler)
+vi.stubGlobal('getRequestIP', () => undefined) // client-IP forwarding is covered in tests/server/utils/api.test.ts
 
 describe('Admin API - Me (Profile)', () => {
   let handler: any

--- a/tests/server/api/admin/projects.get.test.ts
+++ b/tests/server/api/admin/projects.get.test.ts
@@ -15,6 +15,7 @@ vi.stubGlobal('createError', vi.fn((opts: any) => {
   return err
 }))
 vi.stubGlobal('defineEventHandler', vi.fn((handler: Function) => handler))
+vi.stubGlobal('getRequestIP', () => undefined) // client-IP forwarding is covered in tests/server/utils/api.test.ts
 vi.stubGlobal('$fetch', vi.fn(() => Promise.resolve({ data: [] })))
 
 // ---------- Import handler after stubs are set up ----------

--- a/tests/server/api/admin/projects.post.test.ts
+++ b/tests/server/api/admin/projects.post.test.ts
@@ -15,6 +15,7 @@ vi.stubGlobal('createError', vi.fn((opts: any) => {
   return err
 }))
 vi.stubGlobal('defineEventHandler', vi.fn((handler: Function) => handler))
+vi.stubGlobal('getRequestIP', () => undefined) // client-IP forwarding is covered in tests/server/utils/api.test.ts
 vi.stubGlobal('$fetch', vi.fn(() => Promise.resolve({ data: {} })))
 
 // ---------- Import handler after stubs are set up ----------

--- a/tests/server/api/contacts.post.test.ts
+++ b/tests/server/api/contacts.post.test.ts
@@ -15,6 +15,7 @@ vi.stubGlobal('createError', mockCreateError)
 
 const mockFetch = vi.fn()
 vi.stubGlobal('$fetch', mockFetch)
+vi.stubGlobal('getRequestIP', () => undefined) // client-IP forwarding is covered in tests/server/utils/api.test.ts
 vi.stubGlobal('defineEventHandler', (handler: any) => handler)
 
 describe('Contacts API (POST)', () => {

--- a/tests/server/api/health.detailed.get.test.ts
+++ b/tests/server/api/health.detailed.get.test.ts
@@ -8,6 +8,7 @@ vi.stubGlobal('useRuntimeConfig', () => mockConfig)
 
 const mockFetch = vi.fn()
 vi.stubGlobal('$fetch', mockFetch)
+vi.stubGlobal('getRequestIP', () => undefined) // client-IP forwarding is covered in tests/server/utils/api.test.ts
 vi.stubGlobal('defineEventHandler', (handler: any) => handler)
 
 describe('Health API - Detailed', () => {

--- a/tests/server/api/health.get.test.ts
+++ b/tests/server/api/health.get.test.ts
@@ -15,6 +15,7 @@ vi.stubGlobal('setResponseStatus', mockSetResponseStatus)
 
 const mockFetch = vi.fn()
 vi.stubGlobal('$fetch', mockFetch)
+vi.stubGlobal('getRequestIP', () => undefined) // client-IP forwarding is covered in tests/server/utils/api.test.ts
 
 // Mock event handler definition
 vi.stubGlobal('defineEventHandler', (handler: any) => handler)

--- a/tests/server/api/health.live.get.test.ts
+++ b/tests/server/api/health.live.get.test.ts
@@ -8,6 +8,7 @@ vi.stubGlobal('useRuntimeConfig', () => mockConfig)
 
 const mockFetch = vi.fn()
 vi.stubGlobal('$fetch', mockFetch)
+vi.stubGlobal('getRequestIP', () => undefined) // client-IP forwarding is covered in tests/server/utils/api.test.ts
 vi.stubGlobal('defineEventHandler', (handler: any) => handler)
 
 describe('Health API - Live', () => {

--- a/tests/server/api/health.ready.get.test.ts
+++ b/tests/server/api/health.ready.get.test.ts
@@ -8,6 +8,7 @@ vi.stubGlobal('useRuntimeConfig', () => mockConfig)
 
 const mockFetch = vi.fn()
 vi.stubGlobal('$fetch', mockFetch)
+vi.stubGlobal('getRequestIP', () => undefined) // client-IP forwarding is covered in tests/server/utils/api.test.ts
 vi.stubGlobal('defineEventHandler', (handler: any) => handler)
 
 describe('Health API - Ready', () => {

--- a/tests/server/api/index.get.test.ts
+++ b/tests/server/api/index.get.test.ts
@@ -7,6 +7,7 @@ vi.stubGlobal('useRuntimeConfig', () => mockConfig)
 
 const mockFetch = vi.fn()
 vi.stubGlobal('$fetch', mockFetch)
+vi.stubGlobal('getRequestIP', () => undefined) // client-IP forwarding is covered in tests/server/utils/api.test.ts
 vi.stubGlobal('defineEventHandler', (handler: any) => handler)
 
 describe('Index API', () => {
@@ -28,7 +29,9 @@ describe('Index API', () => {
     const result = await handler({} as any)
 
     expect(mockFetch).toHaveBeenCalledWith('https://api.example.com/', {
-      method: 'GET'
+      method: 'GET',
+      // apiFetch always passes a headers object (empty here: no auth, IP unresolved in test)
+      headers: {}
     })
 
     expect(result).toEqual({

--- a/tests/server/api/profile.get.test.ts
+++ b/tests/server/api/profile.get.test.ts
@@ -9,6 +9,7 @@ vi.stubGlobal('useRuntimeConfig', () => mockConfig)
 
 const mockFetch = vi.fn()
 vi.stubGlobal('$fetch', mockFetch)
+vi.stubGlobal('getRequestIP', () => undefined) // client-IP forwarding is covered in tests/server/utils/api.test.ts
 vi.stubGlobal('defineEventHandler', (handler: any) => handler)
 
 describe('Profile API', () => {

--- a/tests/server/api/projects.get.test.ts
+++ b/tests/server/api/projects.get.test.ts
@@ -10,6 +10,7 @@ vi.stubGlobal('getQuery', () => ({}))
 
 const mockFetch = vi.fn()
 vi.stubGlobal('$fetch', mockFetch)
+vi.stubGlobal('getRequestIP', () => undefined) // client-IP forwarding is covered in tests/server/utils/api.test.ts
 vi.stubGlobal('defineEventHandler', (handler: any) => handler)
 
 describe('Projects API (GET)', () => {

--- a/tests/server/api/projects.post.test.ts
+++ b/tests/server/api/projects.post.test.ts
@@ -14,6 +14,7 @@ vi.stubGlobal('readBody', () => Promise.resolve(mockBody))
 
 const mockFetch = vi.fn()
 vi.stubGlobal('$fetch', mockFetch)
+vi.stubGlobal('getRequestIP', () => undefined) // client-IP forwarding is covered in tests/server/utils/api.test.ts
 vi.stubGlobal('defineEventHandler', (handler: any) => handler)
 
 describe('Projects API (POST)', () => {

--- a/tests/server/utils/api.test.ts
+++ b/tests/server/utils/api.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockConfig = {
+  apiBaseUrl: 'https://api.example.com',
+  apiBasePath: '/api/v1',
+}
+vi.stubGlobal('useRuntimeConfig', () => mockConfig)
+
+const mockFetch = vi.fn()
+vi.stubGlobal('$fetch', mockFetch)
+
+const mockGetRequestIP = vi.fn()
+vi.stubGlobal('getRequestIP', mockGetRequestIP)
+
+describe('apiFetch helper', () => {
+  let apiFetch: (typeof import('~/server/utils/api'))['apiFetch']
+  const event = { __isEvent: true } as never
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    mockGetRequestIP.mockReturnValue('203.0.113.7')
+    mockFetch.mockResolvedValue({ ok: true })
+    apiFetch = (await import('~/server/utils/api')).apiFetch
+  })
+
+  it('composes the versioned URL by default and forwards the client IP', async () => {
+    await apiFetch(event, '/projects', {
+      method: 'GET',
+      headers: { 'x-api-key': 'k' },
+    })
+
+    expect(mockGetRequestIP).toHaveBeenCalledWith(event, { xForwardedFor: true })
+    expect(mockFetch).toHaveBeenCalledWith('https://api.example.com/api/v1/projects', {
+      method: 'GET',
+      headers: { 'x-api-key': 'k', 'x-forwarded-for': '203.0.113.7' },
+    })
+  })
+
+  it('omits the base path when basePath is false', async () => {
+    await apiFetch(event, '/health', { method: 'GET', basePath: false })
+
+    expect(mockFetch).toHaveBeenCalledWith('https://api.example.com/health', {
+      method: 'GET',
+      headers: { 'x-forwarded-for': '203.0.113.7' },
+    })
+  })
+
+  it('forwards a single X-Forwarded-For value and never leaks the basePath flag downstream', async () => {
+    await apiFetch(event, '/chat', { method: 'POST', body: { q: 1 } })
+
+    const [, opts] = mockFetch.mock.calls[0]
+    expect(opts).not.toHaveProperty('basePath')
+    expect(opts.headers['x-forwarded-for']).toBe('203.0.113.7')
+  })
+
+  it('omits X-Forwarded-For when the client IP cannot be resolved', async () => {
+    mockGetRequestIP.mockReturnValue(undefined)
+
+    await apiFetch(event, '/profile', { method: 'GET', headers: { foo: 'bar' } })
+
+    const [, opts] = mockFetch.mock.calls[0]
+    expect(opts.headers).toEqual({ foo: 'bar' })
+    expect(opts.headers).not.toHaveProperty('x-forwarded-for')
+  })
+})


### PR DESCRIPTION
## Why
The BFF reaches the backend over the internal docker network (bypassing Traefik), so without an explicit `X-Forwarded-For` the backend saw **every visitor as the single Nuxt container IP** — its per-IP rate limit collapsed into one shared bucket. A few page loads across all visitors could exhaust a low global limit.

## What
1. **`refactor(server)`** — extract the duplicated `$fetch(${apiBaseUrl}${apiBasePath}…)` pattern from all 23 backend-calling BFF routes into a single `apiFetch(event, path, opts)` helper (`src/server/utils/api.ts`). Owns URL composition; threads `event` through. No behavior change.
2. **`feat(server)`** — `apiFetch` reads the trusted client IP (`getRequestIP` leftmost — the true client because Traefik strips client-supplied XFF at the edge) and forwards it as a single clean value on the internal hop.

## Verification
- 262 unit tests green (incl. new `api.test.ts`: URL composition, IP forwarding, single-value, no-IP); `yarn build` + typecheck clean.
- **Empirical (prod):** Traefik strips public XFF (7 spoofed XFF → all one 429 bucket); backend honors a forwarded XFF on the internal hop with `trust proxy 1` (7 distinct XFF → 7 buckets, same XFF → throttles).

## Backend
Pairs with cativo23/portfolio-api PR (trust-proxy invariant doc + THROTTLE_LIMIT alignment). Backend `trust proxy` stays `1` — both the public and BFF paths are exactly one proxy hop.

## Architecture
Decision recorded in two ADRs (centralized helper for all routes; keep `trust proxy 1` + document the invariant; dedicated app↔api network parked as future hardening).