### PR TITLE
🐛 fix(signal): call versioned /api/v1/infra/stats path

### DIFF
--- a/src/server/api/signal.get.ts
+++ b/src/server/api/signal.get.ts
@@ -138,13 +138,14 @@ async function fetchNpmPackageCount(): Promise<number> {
 }
 
 async function fetchInfraStats(event: H3Event): Promise<InfraStats> {
-  // Unversioned endpoint on portfolio-api (basePath: false). It already degrades
-  // to nulls on a docker-proxy outage; the try/catch guards a transport failure.
+  // Versioned endpoint on portfolio-api — it lives under the global /api/v1 prefix
+  // (unlike /health and /, which are excluded), so use the default basePath. The
+  // backend already degrades to null counts on a docker-proxy outage; the
+  // try/catch guards a transport failure so the panel never breaks.
   try {
     const res = await apiFetch<{ status: string; data: InfraStats }>(
       event,
-      '/infra/stats',
-      { basePath: false }
+      '/infra/stats'
     )
     return res?.data ?? { containers: null, stacks: null }
   } catch {

--- a/tests/server/api/signal.get.test.ts
+++ b/tests/server/api/signal.get.test.ts
@@ -56,6 +56,16 @@ describe('Signal API', () => {
     expect(result.data.infra).toEqual({ containers: 20, stacks: 12 })
   })
 
+  it('requests the infra endpoint under the versioned /api/v1 prefix', async () => {
+    await handler({} as any)
+    // The endpoint lives behind portfolio-api's global /api/v1 prefix; a bare
+    // /infra/stats 404s in prod. Assert the composed URL includes the prefix.
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.example.com/api/v1/infra/stats',
+      expect.anything()
+    )
+  })
+
   it('degrades infra counts to null when the endpoint fails', async () => {
     mockFetch.mockImplementation((url: string) => {
       if (url.includes('/infra/stats')) return Promise.reject(new Error('ECONNREFUSED'))


### PR DESCRIPTION
## Problem

`fetchInfraStats` called `apiFetch(..., { basePath: false })` → `https://api.cativo.dev/infra/stats`, which **404s in prod**: portfolio-api applies a global `api/v1` prefix and only excludes `/health`* and `/`. Verified against prod — the endpoint lives at `/api/v1/infra/stats` (returns `{containers, stacks}` live). The container/stack counts would have rendered `...` forever.

Caught by the post-deploy prod smoke test of portfolio-api 2.14.0, not by unit tests (the mock matched on substring, so the missing prefix slipped through — as did the independent review).

## Fix

- Drop `basePath: false` so `apiFetch` composes the versioned URL (`apiBaseUrl + /api/v1 + /infra/stats`).
- Add a test asserting the composed URL includes the `/api/v1` prefix, so a bare path regresses loudly.

## Tests

6/6 signal tests pass.