### PR TITLE
🚀 Release 1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.0] - 2026-07-16
+
+### Changed
+- **SIGNAL panel numbers are now live** — the NPM-package count, running-container count, and compose-stack count under the `LIVE` badge are sourced from real data (npm registry maintainer search + portfolio-api `/api/v1/infra/stats`) instead of hardcoded values that had drifted from reality. Each degrades gracefully to a loading placeholder if its source is unreachable. (#140, #141)
+
+---
+
 ## [1.15.0] - 2026-07-16
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-app",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/components/home/ProofOfWork.vue
+++ b/src/components/home/ProofOfWork.vue
@@ -145,7 +145,7 @@ interface NpmPackageData {
 
 interface SignalData {
   github: { contributions: number; weeks: number[][]; publicRepos: number }
-  npm: { lumira: NpmPackageData | number; claudeStyle: NpmPackageData | number; nightwire: NpmPackageData | number; total: number; packages: number }
+  npm: { lumira: NpmPackageData | number; claudeStyle: NpmPackageData | number; nightwire: NpmPackageData | number; total: number; packages: number | null }
   api: { version: string; status: string }
   infra: { containers: number | null; stacks: number | null }
 }

--- a/src/components/home/ProofOfWork.vue
+++ b/src/components/home/ProofOfWork.vue
@@ -116,7 +116,7 @@
       <div class="metric-cell">
         <div class="m-label">CONTAINERS</div>
         <div class="m-value">{{ signal?.infra.containers ?? '...' }}</div>
-        <div class="m-sub">self-hosted · {{ signal?.infra.stacks ?? '…' }} stacks</div>
+        <div class="m-sub">self-hosted · {{ signal?.infra.stacks ?? '...' }} stacks</div>
       </div>
     </div>
 
@@ -128,9 +128,9 @@
       <span> → </span>
       <span class="text-nw-green">"{{ signal?.api.status ?? '...' }}"</span>
       <span> · </span>
-      <span class="text-nw-yellow">{{ signal?.infra.containers ?? '…' }}</span>
+      <span class="text-nw-yellow">{{ signal?.infra.containers ?? '...' }}</span>
       <span> containers · </span>
-      <span class="text-nw-yellow">{{ signal?.infra.stacks ?? '…' }}</span>
+      <span class="text-nw-yellow">{{ signal?.infra.stacks ?? '...' }}</span>
       <span> stacks</span>
       <span class="inline-block w-[7px] h-[13px] bg-nw-green align-text-bottom" style="animation: nw-caret-blink 1s steps(2) infinite;" />
     </div>

--- a/src/components/home/ProofOfWork.vue
+++ b/src/components/home/ProofOfWork.vue
@@ -53,7 +53,7 @@
         </div>
         <div class="metric-cell">
           <div class="m-value" style="color: var(--nw-primary); text-shadow: 0 0 6px rgba(102,153,255,0.3);">
-            4
+            {{ signal?.npm.packages ?? '...' }}
           </div>
           <div class="m-label">NPM Packages</div>
         </div>
@@ -115,8 +115,8 @@
       </div>
       <div class="metric-cell">
         <div class="m-label">CONTAINERS</div>
-        <div class="m-value">16</div>
-        <div class="m-sub">self-hosted · 6 stacks</div>
+        <div class="m-value">{{ signal?.infra.containers ?? '...' }}</div>
+        <div class="m-sub">self-hosted · {{ signal?.infra.stacks ?? '…' }} stacks</div>
       </div>
     </div>
 
@@ -128,9 +128,9 @@
       <span> → </span>
       <span class="text-nw-green">"{{ signal?.api.status ?? '...' }}"</span>
       <span> · </span>
-      <span class="text-nw-yellow">16</span>
+      <span class="text-nw-yellow">{{ signal?.infra.containers ?? '…' }}</span>
       <span> containers · </span>
-      <span class="text-nw-yellow">6</span>
+      <span class="text-nw-yellow">{{ signal?.infra.stacks ?? '…' }}</span>
       <span> stacks</span>
       <span class="inline-block w-[7px] h-[13px] bg-nw-green align-text-bottom" style="animation: nw-caret-blink 1s steps(2) infinite;" />
     </div>
@@ -145,8 +145,9 @@ interface NpmPackageData {
 
 interface SignalData {
   github: { contributions: number; weeks: number[][]; publicRepos: number }
-  npm: { lumira: NpmPackageData | number; claudeStyle: NpmPackageData | number; nightwire: NpmPackageData | number; total: number }
+  npm: { lumira: NpmPackageData | number; claudeStyle: NpmPackageData | number; nightwire: NpmPackageData | number; total: number; packages: number }
   api: { version: string; status: string }
+  infra: { containers: number | null; stacks: number | null }
 }
 
 const { data: raw } = useFetch<{ status: string; data: SignalData }>('/api/signal', {

--- a/src/server/api/signal.get.ts
+++ b/src/server/api/signal.get.ts
@@ -1,6 +1,14 @@
+import type { H3Event } from 'h3'
+import { apiFetch } from '~/server/utils/api'
+
 interface NpmPackageData {
   monthly: number
   weekly: number[]
+}
+
+interface InfraStats {
+  containers: number | null
+  stacks: number | null
 }
 
 interface SignalData {
@@ -14,11 +22,15 @@ interface SignalData {
     claudeStyle: NpmPackageData
     nightwire: NpmPackageData
     total: number
+    /** Total published packages (maintainer:cativo23), live from the registry. */
+    packages: number
   }
   api: {
     version: string
     status: string
   }
+  /** Live self-hosted infra counts, sourced from portfolio-api. */
+  infra: InfraStats
 }
 
 async function fetchGitHubContributions(token: string): Promise<{ contributions: number; weeks: number[][] }> {
@@ -106,6 +118,32 @@ async function fetchNpmDownloads(pkg: string): Promise<NpmPackageData> {
   return { monthly, weekly }
 }
 
+async function fetchNpmPackageCount(): Promise<number> {
+  // `objects.length` is the exact returned set; size=250 comfortably covers a
+  // personal account, so it won't be capped. Preferred over `total`, which the
+  // registry can inflate for fuzzy maintainer matches.
+  const res = await $fetch<any>(
+    'https://registry.npmjs.org/-/v1/search?text=maintainer:cativo23&size=250',
+    { timeout: 5000 }
+  )
+  return Array.isArray(res?.objects) ? res.objects.length : 0
+}
+
+async function fetchInfraStats(event: H3Event): Promise<InfraStats> {
+  // Unversioned endpoint on portfolio-api (basePath: false). It already degrades
+  // to nulls on a docker-proxy outage; the try/catch guards a transport failure.
+  try {
+    const res = await apiFetch<{ status: string; data: InfraStats }>(
+      event,
+      '/infra/stats',
+      { basePath: false }
+    )
+    return res?.data ?? { containers: null, stacks: null }
+  } catch {
+    return { containers: null, stacks: null }
+  }
+}
+
 async function fetchApiHealth(): Promise<{ version: string; status: string }> {
   try {
     const res = await $fetch<any>('https://api.cativo.dev', { timeout: 5000 })
@@ -121,14 +159,17 @@ async function fetchApiHealth(): Promise<{ version: string; status: string }> {
 export default defineCachedEventHandler(
   async (event) => {
     const { githubToken } = useRuntimeConfig(event)
-    const [gh, repos, lumira, claudeStyle, nightwire, api] = await Promise.allSettled([
-      fetchGitHubContributions(githubToken),
-      fetchGitHubRepos(githubToken),
-      fetchNpmDownloads('lumira'),
-      fetchNpmDownloads('claude-style'),
-      fetchNpmDownloads('@cativo23/nightwire'),
-      fetchApiHealth(),
-    ])
+    const [gh, repos, lumira, claudeStyle, nightwire, api, npmCount, infra] =
+      await Promise.allSettled([
+        fetchGitHubContributions(githubToken),
+        fetchGitHubRepos(githubToken),
+        fetchNpmDownloads('lumira'),
+        fetchNpmDownloads('claude-style'),
+        fetchNpmDownloads('@cativo23/nightwire'),
+        fetchApiHealth(),
+        fetchNpmPackageCount(),
+        fetchInfraStats(event),
+      ])
 
     const ghData = gh.status === 'fulfilled' ? gh.value : { contributions: 0, weeks: [] }
     const repoCount = repos.status === 'fulfilled' ? repos.value : 0
@@ -137,6 +178,11 @@ export default defineCachedEventHandler(
     const claudeStyleDl = claudeStyle.status === 'fulfilled' ? claudeStyle.value : fallbackPkg
     const nightwireDl = nightwire.status === 'fulfilled' ? nightwire.value : fallbackPkg
     const apiData = api.status === 'fulfilled' ? api.value : { version: '...', status: 'unknown' }
+    const packageCount = npmCount.status === 'fulfilled' ? npmCount.value : 0
+    const infraData =
+      infra.status === 'fulfilled'
+        ? infra.value
+        : { containers: null, stacks: null }
 
     const data: SignalData = {
       github: {
@@ -149,8 +195,10 @@ export default defineCachedEventHandler(
         claudeStyle: claudeStyleDl,
         nightwire: nightwireDl,
         total: lumiraDl.monthly + claudeStyleDl.monthly + nightwireDl.monthly,
+        packages: packageCount,
       },
       api: apiData,
+      infra: infraData,
     }
 
     return { status: 'success', data }

--- a/src/server/api/signal.get.ts
+++ b/src/server/api/signal.get.ts
@@ -138,13 +138,14 @@ async function fetchNpmPackageCount(): Promise<number> {
 }
 
 async function fetchInfraStats(event: H3Event): Promise<InfraStats> {
-  // Unversioned endpoint on portfolio-api (basePath: false). It already degrades
-  // to nulls on a docker-proxy outage; the try/catch guards a transport failure.
+  // Versioned endpoint on portfolio-api — it lives under the global /api/v1 prefix
+  // (unlike /health and /, which are excluded), so use the default basePath. The
+  // backend already degrades to null counts on a docker-proxy outage; the
+  // try/catch guards a transport failure so the panel never breaks.
   try {
     const res = await apiFetch<{ status: string; data: InfraStats }>(
       event,
-      '/infra/stats',
-      { basePath: false }
+      '/infra/stats'
     )
     return res?.data ?? { containers: null, stacks: null }
   } catch {

--- a/src/server/api/signal.get.ts
+++ b/src/server/api/signal.get.ts
@@ -22,8 +22,11 @@ interface SignalData {
     claudeStyle: NpmPackageData
     nightwire: NpmPackageData
     total: number
-    /** Total published packages (maintainer:cativo23), live from the registry. */
-    packages: number
+    /**
+     * Total published packages (maintainer:cativo23), live from the registry;
+     * null when the count couldn't be determined (so the UI shows '…', not '0').
+     */
+    packages: number | null
   }
   api: {
     version: string
@@ -126,7 +129,12 @@ async function fetchNpmPackageCount(): Promise<number> {
     'https://registry.npmjs.org/-/v1/search?text=maintainer:cativo23&size=250',
     { timeout: 5000 }
   )
-  return Array.isArray(res?.objects) ? res.objects.length : 0
+  // Throw on a malformed response so the caller degrades to null (→ '…') rather
+  // than reporting a misleading "0" as if it were a real count.
+  if (!Array.isArray(res?.objects)) {
+    throw new Error('unexpected npm registry response shape')
+  }
+  return res.objects.length
 }
 
 async function fetchInfraStats(event: H3Event): Promise<InfraStats> {
@@ -178,7 +186,7 @@ export default defineCachedEventHandler(
     const claudeStyleDl = claudeStyle.status === 'fulfilled' ? claudeStyle.value : fallbackPkg
     const nightwireDl = nightwire.status === 'fulfilled' ? nightwire.value : fallbackPkg
     const apiData = api.status === 'fulfilled' ? api.value : { version: '...', status: 'unknown' }
-    const packageCount = npmCount.status === 'fulfilled' ? npmCount.value : 0
+    const packageCount = npmCount.status === 'fulfilled' ? npmCount.value : null
     const infraData =
       infra.status === 'fulfilled'
         ? infra.value

--- a/tests/server/api/signal.get.test.ts
+++ b/tests/server/api/signal.get.test.ts
@@ -40,6 +40,7 @@ describe('Signal API', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks()
+    vi.resetModules() // isolate the dynamic import so no module state leaks between tests
     mockFetch.mockImplementation((url: string) => defaultRoute(url))
     const module = await import('~/server/api/signal.get')
     handler = module.default
@@ -64,7 +65,7 @@ describe('Signal API', () => {
     expect(result.data.infra).toEqual({ containers: null, stacks: null })
   })
 
-  it('falls back to 0 packages when the registry search fails', async () => {
+  it('degrades package count to null when the registry search fails', async () => {
     mockFetch.mockImplementation((url: string) => {
       if (url.includes('registry.npmjs.org/-/v1/search')) {
         return Promise.reject(new Error('timeout'))
@@ -72,6 +73,17 @@ describe('Signal API', () => {
       return defaultRoute(url)
     })
     const result = await handler({} as any)
-    expect(result.data.npm.packages).toBe(0)
+    expect(result.data.npm.packages).toBeNull()
+  })
+
+  it('degrades package count to null on a malformed registry response', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('registry.npmjs.org/-/v1/search')) {
+        return Promise.resolve({ objects: null }) // no usable objects array
+      }
+      return defaultRoute(url)
+    })
+    const result = await handler({} as any)
+    expect(result.data.npm.packages).toBeNull()
   })
 })

--- a/tests/server/api/signal.get.test.ts
+++ b/tests/server/api/signal.get.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockConfig = {
+  githubToken: '',
+  apiBaseUrl: 'https://api.example.com',
+  apiBasePath: '/api/v1',
+}
+vi.stubGlobal('useRuntimeConfig', () => mockConfig)
+vi.stubGlobal('getRequestIP', () => undefined)
+
+const mockFetch = vi.fn()
+vi.stubGlobal('$fetch', mockFetch)
+
+// Cached handler wrapper — ignore cache options, return the raw handler.
+vi.stubGlobal('defineCachedEventHandler', (handler: any) => handler)
+
+/** Default happy-path routing for every upstream signal.get talks to. */
+function defaultRoute(url: string) {
+  if (url.includes('/infra/stats')) {
+    return Promise.resolve({ status: 'success', data: { containers: 20, stacks: 12 } })
+  }
+  if (url.includes('registry.npmjs.org/-/v1/search')) {
+    return Promise.resolve({ objects: [{}, {}, {}, {}] }) // 4 packages
+  }
+  if (url.includes('api.npmjs.org/downloads')) {
+    return Promise.resolve({ downloads: 0 })
+  }
+  if (url.includes('api.github.com/graphql')) {
+    return Promise.resolve({ data: { user: null } })
+  }
+  if (url.includes('api.github.com/users')) {
+    return Promise.resolve({ public_repos: 42 })
+  }
+  // api health root
+  return Promise.resolve({ data: { version: '2.13.0', status: 'operational' } })
+}
+
+describe('Signal API', () => {
+  let handler: any
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    mockFetch.mockImplementation((url: string) => defaultRoute(url))
+    const module = await import('~/server/api/signal.get')
+    handler = module.default
+  })
+
+  it('exposes the live npm package count from the registry', async () => {
+    const result = await handler({} as any)
+    expect(result.data.npm.packages).toBe(4)
+  })
+
+  it('exposes live container/stack counts from portfolio-api', async () => {
+    const result = await handler({} as any)
+    expect(result.data.infra).toEqual({ containers: 20, stacks: 12 })
+  })
+
+  it('degrades infra counts to null when the endpoint fails', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('/infra/stats')) return Promise.reject(new Error('ECONNREFUSED'))
+      return defaultRoute(url)
+    })
+    const result = await handler({} as any)
+    expect(result.data.infra).toEqual({ containers: null, stacks: null })
+  })
+
+  it('falls back to 0 packages when the registry search fails', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('registry.npmjs.org/-/v1/search')) {
+        return Promise.reject(new Error('timeout'))
+      }
+      return defaultRoute(url)
+    })
+    const result = await handler({} as any)
+    expect(result.data.npm.packages).toBe(0)
+  })
+})

--- a/tests/server/api/signal.get.test.ts
+++ b/tests/server/api/signal.get.test.ts
@@ -56,6 +56,16 @@ describe('Signal API', () => {
     expect(result.data.infra).toEqual({ containers: 20, stacks: 12 })
   })
 
+  it('requests the infra endpoint under the versioned /api/v1 prefix', async () => {
+    await handler({} as any)
+    // The endpoint lives behind portfolio-api's global /api/v1 prefix; a bare
+    // /infra/stats 404s in prod. Assert the composed URL includes the prefix.
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.example.com/api/v1/infra/stats',
+      expect.anything()
+    )
+  })
+
   it('degrades infra counts to null when the endpoint fails', async () => {
     mockFetch.mockImplementation((url: string) => {
       if (url.includes('/infra/stats')) return Promise.reject(new Error('ECONNREFUSED'))


### PR DESCRIPTION
## Summary

This release brings live data integration to the SIGNAL panel, replacing hardcoded npm package and infrastructure metrics with real-time values sourced from the npm registry maintainer search and portfolio-api `/api/v1/infra/stats` endpoint. Each data point degrades gracefully if its source is unreachable.

## Highlights

- **SIGNAL panel numbers are now live** — the NPM-package count, running-container count, and compose-stack count under the `LIVE` badge are sourced from real data (npm registry maintainer search + portfolio-api `/api/v1/infra/stats`) instead of hardcoded values that had drifted from reality. Each degrades gracefully to a loading placeholder if its source is unreachable. (#140, #141)

## Test plan

- [x] CI `build` green on source PRs
- [ ] Post-merge: auto-release tags `v1.16.0` and publishes GitHub Release
- [ ] Post-merge: Deploy workflow succeeds on polaris2
- [ ] Post-deploy: `curl -I https://cativo.dev/` shows expected headers
- [ ] Post-deploy: container reports `healthy`
- [ ] Post-release: `main` merged back to `develop`
- [ ] Verify prod: `curl -s https://cativo.dev/api/signal` returns JSON with non-null `data.infra.containers`, `data.infra.stacks`, and `data.npm.packages`

Refs #140 #141