### PR TITLE
feat(signal): show Traefik-exposed services, not raw containers

### DIFF
--- a/src/components/home/ProofOfWork.vue
+++ b/src/components/home/ProofOfWork.vue
@@ -114,8 +114,8 @@
         <div class="m-sub">ISO 8583 · multi-gateway</div>
       </div>
       <div class="metric-cell">
-        <div class="m-label">CONTAINERS</div>
-        <div class="m-value">{{ signal?.infra.containers ?? '...' }}</div>
+        <div class="m-label">SERVICES</div>
+        <div class="m-value">{{ signal?.infra.services ?? '...' }}</div>
         <div class="m-sub">self-hosted · {{ signal?.infra.stacks ?? '...' }} stacks</div>
       </div>
     </div>
@@ -128,8 +128,8 @@
       <span> → </span>
       <span class="text-nw-green">"{{ signal?.api.status ?? '...' }}"</span>
       <span> · </span>
-      <span class="text-nw-yellow">{{ signal?.infra.containers ?? '...' }}</span>
-      <span> containers · </span>
+      <span class="text-nw-yellow">{{ signal?.infra.services ?? '...' }}</span>
+      <span> services · </span>
       <span class="text-nw-yellow">{{ signal?.infra.stacks ?? '...' }}</span>
       <span> stacks</span>
       <span class="inline-block w-[7px] h-[13px] bg-nw-green align-text-bottom" style="animation: nw-caret-blink 1s steps(2) infinite;" />
@@ -147,7 +147,7 @@ interface SignalData {
   github: { contributions: number; weeks: number[][]; publicRepos: number }
   npm: { lumira: NpmPackageData | number; claudeStyle: NpmPackageData | number; nightwire: NpmPackageData | number; total: number; packages: number | null }
   api: { version: string; status: string }
-  infra: { containers: number | null; stacks: number | null }
+  infra: { services: number | null; stacks: number | null }
 }
 
 const { data: raw } = useFetch<{ status: string; data: SignalData }>('/api/signal', {

--- a/src/server/api/signal.get.ts
+++ b/src/server/api/signal.get.ts
@@ -7,7 +7,7 @@ interface NpmPackageData {
 }
 
 interface InfraStats {
-  containers: number | null
+  services: number | null
   stacks: number | null
 }
 
@@ -147,9 +147,9 @@ async function fetchInfraStats(event: H3Event): Promise<InfraStats> {
       event,
       '/infra/stats'
     )
-    return res?.data ?? { containers: null, stacks: null }
+    return res?.data ?? { services: null, stacks: null }
   } catch {
-    return { containers: null, stacks: null }
+    return { services: null, stacks: null }
   }
 }
 
@@ -191,7 +191,7 @@ export default defineCachedEventHandler(
     const infraData =
       infra.status === 'fulfilled'
         ? infra.value
-        : { containers: null, stacks: null }
+        : { services: null, stacks: null }
 
     const data: SignalData = {
       github: {

--- a/tests/server/api/signal.get.test.ts
+++ b/tests/server/api/signal.get.test.ts
@@ -17,7 +17,7 @@ vi.stubGlobal('defineCachedEventHandler', (handler: any) => handler)
 /** Default happy-path routing for every upstream signal.get talks to. */
 function defaultRoute(url: string) {
   if (url.includes('/infra/stats')) {
-    return Promise.resolve({ status: 'success', data: { containers: 20, stacks: 12 } })
+    return Promise.resolve({ status: 'success', data: { services: 17, stacks: 12 } })
   }
   if (url.includes('registry.npmjs.org/-/v1/search')) {
     return Promise.resolve({ objects: [{}, {}, {}, {}] }) // 4 packages
@@ -51,9 +51,9 @@ describe('Signal API', () => {
     expect(result.data.npm.packages).toBe(4)
   })
 
-  it('exposes live container/stack counts from portfolio-api', async () => {
+  it('exposes live service/stack counts from portfolio-api', async () => {
     const result = await handler({} as any)
-    expect(result.data.infra).toEqual({ containers: 20, stacks: 12 })
+    expect(result.data.infra).toEqual({ services: 17, stacks: 12 })
   })
 
   it('requests the infra endpoint under the versioned /api/v1 prefix', async () => {
@@ -72,7 +72,7 @@ describe('Signal API', () => {
       return defaultRoute(url)
     })
     const result = await handler({} as any)
-    expect(result.data.infra).toEqual({ containers: null, stacks: null })
+    expect(result.data.infra).toEqual({ services: null, stacks: null })
   })
 
   it('degrades package count to null when the registry search fails', async () => {


### PR DESCRIPTION
## What

Pairs with **portfolio-api#143**. The SIGNAL panel's live infra number showed *every running container* (37 on prod) — noise-heavy with exporters/db/redis/proxy. That PR filters to Traefik-exposed services (~17); this one:

- consumes the renamed API field `infra.containers` → `infra.services`
- relabels the metric tile **CONTAINERS → SERVICES** and the terminal ticker (`N containers` → `N services`)

`stacks` (12) is unchanged.

## Tests
- `signal.get.test.ts` updated (mock + assertions → `services`).
- Ran inside the dev container: typecheck clean, **235 tests pass**, `nuxi build` clean.

## Deploy ordering
Backend (#143) must deploy first; until then the frontend falls back to `'...'` (field absent = null), never breaks. Live verify after both ship: `cativo.dev/api/signal` → `infra.services: 17`.