### PR TITLE
fix(signal): use SWR caching so browsers aren't pinned to stale LIVE data

### DIFF
--- a/src/server/api/signal.get.ts
+++ b/src/server/api/signal.get.ts
@@ -212,5 +212,11 @@ export default defineCachedEventHandler(
 
     return { status: 'success', data }
   },
-  { maxAge: 60 * 60 }
+  // Cache the composed payload server-side for an hour so the rate-limited
+  // upstreams (GitHub GraphQL, npm registry) aren't hammered. `swr: true` emits
+  // `s-maxage` + `stale-while-revalidate` instead of a private `max-age`, so the
+  // browser revalidates (cheap via ETag) rather than pinning a stale copy for an
+  // hour — keeps the LIVE numbers fresh and stops payload-shape changes from
+  // replaying broken data to returning visitors.
+  { maxAge: 60 * 60, swr: true }
 )

--- a/tests/server/api/signal.get.test.ts
+++ b/tests/server/api/signal.get.test.ts
@@ -11,8 +11,12 @@ vi.stubGlobal('getRequestIP', () => undefined)
 const mockFetch = vi.fn()
 vi.stubGlobal('$fetch', mockFetch)
 
-// Cached handler wrapper — ignore cache options, return the raw handler.
-vi.stubGlobal('defineCachedEventHandler', (handler: any) => handler)
+// Cached handler wrapper — capture the cache options (asserted below), return the raw handler.
+let cachedOpts: Record<string, unknown> | undefined
+vi.stubGlobal('defineCachedEventHandler', (handler: any, opts: Record<string, unknown>) => {
+  cachedOpts = opts
+  return handler
+})
 
 /** Default happy-path routing for every upstream signal.get talks to. */
 function defaultRoute(url: string) {
@@ -49,6 +53,13 @@ describe('Signal API', () => {
   it('exposes the live npm package count from the registry', async () => {
     const result = await handler({} as any)
     expect(result.data.npm.packages).toBe(4)
+  })
+
+  it('caches server-side for an hour but uses SWR so the browser is not pinned to a stale copy', async () => {
+    // swr:true makes Nitro emit `s-maxage` + `stale-while-revalidate` (shared-cache
+    // only) instead of a private `max-age`, so returning visitors revalidate rather
+    // than replaying a stale payload for an hour. Guards the LIVE-freshness fix.
+    expect(cachedOpts).toMatchObject({ maxAge: 60 * 60, swr: true })
   })
 
   it('exposes live service/stack counts from portfolio-api', async () => {


### PR DESCRIPTION
## Problem

`signal.get.ts` cached with `{ maxAge: 3600 }`. Nitro (2.13.3) emits that as a **private** `Cache-Control: max-age=3600`, so every browser caches the payload for an hour. Combined with `ProofOfWork.vue`'s client-only `useFetch('/api/signal', { server: false })`:

- returning visitors see up-to-1h-stale `LIVE` numbers, and
- any payload **shape** change replays broken data — the recent `containers` → `services` rename showed `... services · 12 stacks` in already-open browsers until the cache expired (server was always correct; verified).

## Fix

Add `swr: true`. Per Nitro's cache source, this emits `s-maxage=3600, stale-while-revalidate` (a **shared-cache** directive) instead of private `max-age`, so the browser revalidates cheaply via the ETag Nitro already sets and always resolves to the current payload. Shape changes propagate immediately (ETag mismatch → 200 fresh).

**Server-side TTL is unchanged** — the cache freshness is still driven by `maxAge` (verified in `nitropack/dist/runtime/internal/cache.mjs`), so the rate-limited upstreams (GitHub GraphQL, npm registry) stay protected; `swr` additionally serves stale-while-revalidating instead of a thundering-herd refetch on expiry.

## Tests
- New regression test asserts the handler is registered with `{ maxAge: 3600, swr: true }`.
- Container run: typecheck clean, signal tests pass, `nuxi build` clean.

## Verify after deploy
`curl -sD- https://cativo.dev/api/signal -o /dev/null | grep cache-control` → should read `s-maxage=3600, stale-while-revalidate` (no private `max-age`).