### PR TITLE
🚀 Release 1.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.1] - 2026-07-16
+
+### Fixed
+- **SIGNAL panel no longer serves stale LIVE numbers from the browser cache** — the `/api/signal` handler now caches with `swr: true`, so Nitro emits `s-maxage` + `stale-while-revalidate` (shared-cache only) instead of a private `max-age=3600`. Returning visitors revalidate via ETag and always get the current payload, and payload-shape changes (like the recent containers → services rename) no longer replay broken data until the browser cache expires. Server-side cache TTL is unchanged, so the rate-limited upstreams stay protected. (#145)
+
+---
+
 ## [1.17.0] - 2026-07-16
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-app",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/server/api/signal.get.ts
+++ b/src/server/api/signal.get.ts
@@ -212,5 +212,11 @@ export default defineCachedEventHandler(
 
     return { status: 'success', data }
   },
-  { maxAge: 60 * 60 }
+  // Cache the composed payload server-side for an hour so the rate-limited
+  // upstreams (GitHub GraphQL, npm registry) aren't hammered. `swr: true` emits
+  // `s-maxage` + `stale-while-revalidate` instead of a private `max-age`, so the
+  // browser revalidates (cheap via ETag) rather than pinning a stale copy for an
+  // hour — keeps the LIVE numbers fresh and stops payload-shape changes from
+  // replaying broken data to returning visitors.
+  { maxAge: 60 * 60, swr: true }
 )

--- a/tests/server/api/signal.get.test.ts
+++ b/tests/server/api/signal.get.test.ts
@@ -11,8 +11,12 @@ vi.stubGlobal('getRequestIP', () => undefined)
 const mockFetch = vi.fn()
 vi.stubGlobal('$fetch', mockFetch)
 
-// Cached handler wrapper — ignore cache options, return the raw handler.
-vi.stubGlobal('defineCachedEventHandler', (handler: any) => handler)
+// Cached handler wrapper — capture the cache options (asserted below), return the raw handler.
+let cachedOpts: Record<string, unknown> | undefined
+vi.stubGlobal('defineCachedEventHandler', (handler: any, opts: Record<string, unknown>) => {
+  cachedOpts = opts
+  return handler
+})
 
 /** Default happy-path routing for every upstream signal.get talks to. */
 function defaultRoute(url: string) {
@@ -49,6 +53,13 @@ describe('Signal API', () => {
   it('exposes the live npm package count from the registry', async () => {
     const result = await handler({} as any)
     expect(result.data.npm.packages).toBe(4)
+  })
+
+  it('caches server-side for an hour but uses SWR so the browser is not pinned to a stale copy', async () => {
+    // swr:true makes Nitro emit `s-maxage` + `stale-while-revalidate` (shared-cache
+    // only) instead of a private `max-age`, so returning visitors revalidate rather
+    // than replaying a stale payload for an hour. Guards the LIVE-freshness fix.
+    expect(cachedOpts).toMatchObject({ maxAge: 60 * 60, swr: true })
   })
 
   it('exposes live service/stack counts from portfolio-api', async () => {


### PR DESCRIPTION
## Summary

Fixed cache-control header on the `/api/signal` endpoint to use shared-cache semantics (`s-maxage` + `stale-while-revalidate`) instead of private browser cache, ensuring returning visitors always revalidate and get fresh LIVE numbers even when payload schema changes.

## Highlights

- **SIGNAL panel no longer serves stale LIVE numbers from the browser cache** — the `/api/signal` handler now caches with `swr: true`, so Nitro emits `s-maxage` + `stale-while-revalidate` (shared-cache only) instead of a private `max-age=3600`. Returning visitors revalidate via ETag and always get the current payload, and payload-shape changes (like the recent containers → services rename) no longer replay broken data until the browser cache expires. Server-side cache TTL is unchanged, so the rate-limited upstreams stay protected.

## Test plan

- [x] CI \`build\` green on source PRs
- [ ] Post-merge: auto-release tags \`v1.17.1\` and publishes GitHub Release
- [ ] Post-merge: Deploy workflow succeeds on polaris2
- [ ] Post-deploy: \`curl -I https://cativo.dev/\` shows expected headers
- [ ] Post-deploy: container reports \`healthy\`
- [ ] Post-deploy: \`curl -sD- https://cativo.dev/api/signal\` shows \`cache-control: s-maxage=3600, stale-while-revalidate\` (NOT private max-age)
- [ ] Post-release: \`main\` merged back to \`develop\`

Refs #145