### PR TITLE
feat(analytics): wire same-origin Umami tracking into the site

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -34,6 +34,9 @@ export default defineNuxtConfig({
     spotifyClientId: '',
     spotifyClientSecret: '',
     spotifyRefreshToken: '',
+    // Internal Umami container on space-server_web; over/ridable via NUXT_UMAMI_URL.
+    // The tracker script (/u.js) and event collector (/api/send) proxy to this.
+    umamiUrl: 'http://umami:3000',
     public: {
       baseTitle: 'Carlos Cativo',
       defaultOgImage: '/img/akira.jpeg',
@@ -67,6 +70,16 @@ export default defineNuxtConfig({
         {
           rel: 'stylesheet',
           href: 'https://fonts.googleapis.com/css2?family=Noto+Serif+Display:wght@700;800;900&family=JetBrains+Mono:wght@400;500;700&family=Saira+Extra+Condensed:wght@400;600;700;800&family=Shippori+Mincho+B1:wght@500;700;800&display=swap'
+        },
+      ],
+      script: [
+        // Umami analytics, loaded same-origin (/u.js proxies the tracker) so the
+        // strict CSP stays intact. nuxt-security stamps the nonce needed under
+        // script-src 'strict-dynamic'. website-id is public (sent to every visitor).
+        {
+          src: '/u.js',
+          defer: true,
+          'data-website-id': '2cecff23-b9d4-4d11-8fae-a0037e4a6b42',
         },
       ],
     },
@@ -126,5 +139,7 @@ export default defineNuxtConfig({
     '/api/chat': { security: { xssValidator: false } },
     '/api/contacts': { security: { xssValidator: false } },
     '/api/csp-report': { security: { xssValidator: false } },
+    // Umami event payloads are JSON with URLs/referrers that trip the XSS validator.
+    '/api/send': { security: { xssValidator: false } },
   },
 })

--- a/src/server/api/send.post.ts
+++ b/src/server/api/send.post.ts
@@ -1,0 +1,39 @@
+/**
+ * Same-origin proxy for Umami's event collector (`/api/send`).
+ *
+ * The tracker (served first-party from `/u.js`) POSTs events here; we forward
+ * them to the internal Umami container. Two headers are LOAD-BEARING for Umami:
+ *   - `user-agent`: Umami rejects events with no UA (400) and uses it, together
+ *     with the IP, to derive the visitor/session hash. Must be the real client's.
+ *   - `x-forwarded-for`: the real client IP (same leftmost-XFF reasoning as
+ *     `server/utils/api.ts` — Traefik strips client XFF at the edge, so the value
+ *     getRequestIP returns is trustworthy). Without it every visitor collapses
+ *     into this container's IP and unique/session counts break.
+ *
+ * Degrades quietly (204) if Umami is unreachable so a tracking blip never
+ * surfaces an error to the visitor.
+ */
+export default defineEventHandler(async (event) => {
+  const { umamiUrl } = useRuntimeConfig(event)
+  const body = await readRawBody(event)
+  const clientIp = getRequestIP(event, { xForwardedFor: true })
+  const userAgent = getHeader(event, 'user-agent')
+
+  const headers: Record<string, string> = { 'content-type': 'application/json' }
+  if (userAgent) headers['user-agent'] = userAgent
+  if (clientIp) headers['x-forwarded-for'] = clientIp
+
+  try {
+    const res = await $fetch<string>(`${umamiUrl}/api/send`, {
+      method: 'POST',
+      headers,
+      body,
+      responseType: 'text',
+      timeout: 5000,
+    })
+    return res
+  } catch {
+    setResponseStatus(event, 204)
+    return null
+  }
+})

--- a/src/server/routes/u.js.get.ts
+++ b/src/server/routes/u.js.get.ts
@@ -1,0 +1,29 @@
+/**
+ * Same-origin proxy for the Umami tracker script.
+ *
+ * Serving the tracker from cativo.dev itself (instead of analytics.cativo.dev)
+ * keeps the site's strict CSP `connect-src 'self'` intact and makes the request
+ * first-party, so ad-blockers that target known analytics hosts don't drop it.
+ * The browser derives the event-collector origin from this script's own URL, so
+ * it POSTs to `/api/send` on cativo.dev — proxied to Umami by `api/send.post.ts`.
+ *
+ * Degrades to an empty (200) script if Umami is unreachable (e.g. local dev,
+ * where the `umami` container isn't on the network) so the page never errors.
+ */
+export default defineEventHandler(async (event) => {
+  const { umamiUrl } = useRuntimeConfig(event)
+  setResponseHeader(event, 'content-type', 'application/javascript; charset=utf-8')
+  // Modest cache; the tracker changes only on an Umami upgrade.
+  setResponseHeader(event, 'cache-control', 'public, max-age=3600')
+
+  try {
+    const script = await $fetch<string>(`${umamiUrl}/script.js`, {
+      responseType: 'text',
+      timeout: 5000,
+    })
+    return script
+  } catch {
+    // No tracker rather than a 500 — analytics is decorative, never load-bearing.
+    return '/* analytics unavailable */'
+  }
+})

--- a/tests/server/api/send.post.test.ts
+++ b/tests/server/api/send.post.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockConfig = { umamiUrl: 'http://umami:3000' }
+vi.stubGlobal('useRuntimeConfig', () => mockConfig)
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+
+const mockFetch = vi.fn()
+vi.stubGlobal('$fetch', mockFetch)
+const mockReadRawBody = vi.fn()
+vi.stubGlobal('readRawBody', mockReadRawBody)
+const mockGetRequestIP = vi.fn()
+vi.stubGlobal('getRequestIP', mockGetRequestIP)
+const mockGetHeader = vi.fn()
+vi.stubGlobal('getHeader', mockGetHeader)
+const mockSetResponseStatus = vi.fn()
+vi.stubGlobal('setResponseStatus', mockSetResponseStatus)
+
+describe('POST /api/send — Umami collector proxy', () => {
+  let handler: any
+  const event = { __isEvent: true } as never
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    mockReadRawBody.mockResolvedValue('{"type":"event"}')
+    mockGetRequestIP.mockReturnValue('203.0.113.7')
+    mockGetHeader.mockReturnValue('Mozilla/5.0 (test)')
+    mockFetch.mockResolvedValue('ok-token')
+    handler = (await import('~/server/api/send.post')).default
+  })
+
+  it('forwards the event to Umami with the real client IP and user-agent', async () => {
+    const res = await handler(event)
+
+    expect(res).toBe('ok-token')
+    expect(mockGetRequestIP).toHaveBeenCalledWith(event, { xForwardedFor: true })
+    const [url, opts] = mockFetch.mock.calls[0]
+    expect(url).toBe('http://umami:3000/api/send')
+    expect(opts.method).toBe('POST')
+    expect(opts.body).toBe('{"type":"event"}')
+    expect(opts.headers['user-agent']).toBe('Mozilla/5.0 (test)')
+    expect(opts.headers['x-forwarded-for']).toBe('203.0.113.7')
+  })
+
+  it('omits x-forwarded-for and user-agent when they cannot be resolved', async () => {
+    mockGetRequestIP.mockReturnValue(undefined)
+    mockGetHeader.mockReturnValue(undefined)
+
+    await handler(event)
+
+    const [, opts] = mockFetch.mock.calls[0]
+    expect(opts.headers).not.toHaveProperty('x-forwarded-for')
+    expect(opts.headers).not.toHaveProperty('user-agent')
+    expect(opts.headers['content-type']).toBe('application/json')
+  })
+
+  it('degrades to 204 (never errors the visitor) when Umami is unreachable', async () => {
+    mockFetch.mockRejectedValue(new Error('ECONNREFUSED'))
+
+    const res = await handler(event)
+
+    expect(res).toBeNull()
+    expect(mockSetResponseStatus).toHaveBeenCalledWith(event, 204)
+  })
+})


### PR DESCRIPTION
## What

Phase 2 of ROADMAP #2 (Phase 1 = the Umami stack on space-server, F48). Wires the tracker into the site **same-origin** so the strict CSP stays intact and ad-blockers don't drop first-party requests.

- **`src/server/routes/u.js.get.ts`** — serves the Umami tracker first-party at `cativo.dev/u.js` (proxies `umami:3000/script.js`). Graceful empty script if Umami is down.
- **`src/server/api/send.post.ts`** — proxies events to `umami:3000/api/send`, forwarding the **real client IP** (`x-forwarded-for`, same pattern as `apiFetch`) and **User-Agent** — both load-bearing for Umami session/visitor hashing. Degrades to 204 if Umami is down.
- **`nuxt.config.ts`** — `runtimeConfig.umamiUrl` (default `http://umami:3000`, works in prod on `space-server_web`); tracker `<script>` in `app.head` with the public `data-website-id`; `/api/send` added to the `xssValidator:false` routes.

## CSP
Unchanged. Collector is same-origin so `connect-src 'self'` covers it; the tracker `<script>` gets nuxt-security's nonce so it satisfies `script-src 'strict-dynamic'`. Verified in the dev container: the rendered tag carries `nonce="…"`.

## Tests
3 new collector tests (forwards IP+UA / omits when absent / 204 on failure). Container run: typecheck clean, full suite green, `nuxi build` clean.

## Verify after deploy
Umami is only reachable from the prod container — after deploy I'll confirm `cativo.dev/u.js` returns the real tracker and a hit lands in the `analytics.cativo.dev` dashboard.