### PR TITLE
fix(privacy): make the closing stamp readable

### DIFF
--- a/src/pages/privacy.vue
+++ b/src/pages/privacy.vue
@@ -95,7 +95,7 @@
           Questions about any of this? Reach me at
           <a href="mailto:cativo@cativo.dev" class="text-nw-primary hover:text-nw-primary-hot underline">cativo@cativo.dev</a>.
         </p>
-        <p class="text-[10px] font-stamp uppercase tracking-[0.18em] text-nw-text-faint mt-3">
+        <p class="text-[10px] font-stamp uppercase tracking-[0.18em] text-nw-text-dim mt-3">
           Not legal boilerplate — just how the stack actually works.
         </p>
       </div>


### PR DESCRIPTION
The `/privacy` closing caption used `text-nw-text-faint` = `rgba(255,255,255,0.06)` — a hairline/border token, not text — so it was nearly invisible unless highlighted. Swapped to `text-nw-text-dim` (`#aaaaaa`), the muted-text token used elsewhere on the site. One-class change.