### PR TITLE
🚀 Release 1.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.1] - 2026-07-16
+
+### Fixed
+- **`/privacy` closing caption was nearly invisible** — it used the hairline/border token `text-nw-text-faint` (rgba 6% white) instead of a text color; switched to `text-nw-text-dim` (#aaaaaa) so it reads as a muted caption. (#153)
+
+---
+
 ## [1.20.0] - 2026-07-16
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-app",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/pages/privacy.vue
+++ b/src/pages/privacy.vue
@@ -95,7 +95,7 @@
           Questions about any of this? Reach me at
           <a href="mailto:cativo@cativo.dev" class="text-nw-primary hover:text-nw-primary-hot underline">cativo@cativo.dev</a>.
         </p>
-        <p class="text-[10px] font-stamp uppercase tracking-[0.18em] text-nw-text-faint mt-3">
+        <p class="text-[10px] font-stamp uppercase tracking-[0.18em] text-nw-text-dim mt-3">
           Not legal boilerplate — just how the stack actually works.
         </p>
       </div>


### PR DESCRIPTION
## Summary

Fixed the `/privacy` closing caption which was nearly invisible due to using an incorrect text color token. The caption now uses the proper muted text color for improved readability.

## Highlights

### Fixed
- **`/privacy` closing caption was nearly invisible** — it used the hairline/border token `text-nw-text-faint` (rgba 6% white) instead of a text color; switched to `text-nw-text-dim` (#aaaaaa) so it reads as a muted caption. (#153)

## Test plan

- [x] CI `build` green on source PRs
- [ ] Post-merge: auto-release tags `v1.20.1` and publishes GitHub Release
- [ ] Post-merge: Deploy workflow succeeds on polaris2
- [ ] Post-deploy: Container reports healthy
- [ ] Post-release: `main` merged back to `develop`

Refs #153