### PR TITLE
🚀 Release 1.20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.2] - 2026-07-16
+
+### Fixed
+- **Admin dashboard metrics strip cramped on mobile** — was a fixed `grid-cols-4` (~80px cells at phone widths); now `grid-cols-2 sm:grid-cols-4` (comfortable 2×2 on mobile, 4-across on larger). Admin-only page; found during a mobile-QA sweep. (#155)
+
+---
+
 ## [1.20.1] - 2026-07-16
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-app",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/pages/admin/index.vue
+++ b/src/pages/admin/index.vue
@@ -3,7 +3,7 @@
     <div class="font-stamp text-[13px] tracking-[0.14em] uppercase text-nw-text">Dashboard</div>
 
     <!-- Metrics strip -->
-    <div class="grid grid-cols-4 gap-px bg-nw-text-faint border border-nw-text-faint">
+    <div class="grid grid-cols-2 sm:grid-cols-4 gap-px bg-nw-text-faint border border-nw-text-faint">
       <div class="bg-void-warm px-4 py-3">
         <div class="font-stamp text-[9px] tracking-[0.14em] uppercase text-nw-primary mb-1">Projects</div>
         <div class="text-[24px] font-bold text-nw-green leading-none" style="text-shadow: 0 0 8px rgba(122,237,122,0.35);">{{ projectCount }}</div>


### PR DESCRIPTION
## Summary

Fix for the admin dashboard metrics display on mobile devices — responsive grid layout replaces the cramped fixed 4-column layout, now comfortable 2×2 on phones and 4-across on larger screens.

## Highlights

- Admin dashboard metrics strip now responsive on mobile (`grid-cols-2 sm:grid-cols-4`), replacing the cramped fixed 4-column layout (#155)

## Test plan

- [x] CI `build` green on source PRs
- [ ] Post-merge: auto-release tags `v1.20.2` and publishes GitHub Release
- [ ] Post-merge: Deploy workflow succeeds on polaris2
- [ ] Post-deploy: `curl -I https://cativo.dev/` shows expected headers
- [ ] Post-deploy: container reports `healthy`
- [ ] Post-release: `main` merged back to `develop`

Refs #155