### PR TITLE
chore(scripts): point CV PDF generator at :3002 dev port

### DIFF
--- a/scripts/build-cv-pdf.sh
+++ b/scripts/build-cv-pdf.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # Regenerate src/public/resume.pdf from the live /cv page.
-# Run while `docker compose up` is up so http://localhost:3001/cv is reachable.
+# Run while `docker compose up` is up so http://localhost:3002/cv is reachable.
 #
 # Usage: ./scripts/build-cv-pdf.sh
 
 set -euo pipefail
 
-URL="${CV_URL:-http://localhost:3001/cv}"
+URL="${CV_URL:-http://localhost:3002/cv}"
 OUT="src/public/resume.pdf"
 
 CHROME=$(command -v google-chrome-stable || command -v google-chrome || command -v chromium || command -v chromium-browser || true)


### PR DESCRIPTION
Stale-port housekeeping surfaced during roadmap #7. `scripts/build-cv-pdf.sh` defaulted `CV_URL` to `http://localhost:3001/cv`, but the dev server now runs on `:3002`. Updated the default and the comment. Dev-only tooling; no app/runtime change.