### PR TITLE
test(server): guard against raw $fetch bypassing apiFetch

### DIFF
--- a/tests/server/api-fetch-convention.test.ts
+++ b/tests/server/api-fetch-convention.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+// Every BFF → backend call must go through server/utils/api.ts's apiFetch(),
+// which is the single place `config.apiBaseUrl` is composed into a URL and
+// forwards the real client IP (see api.ts's LOAD-BEARING throttle comment).
+// A route that calls $fetch(`${config.apiBaseUrl}...`) directly bypasses that
+// IP forwarding and silently collapses every visitor back into one throttle
+// bucket. This test guards against reintroducing that pattern.
+const SERVER_API_DIR = join(__dirname, '../../src/server/api')
+const APIBASEURL_PATTERN = /\bapiBaseUrl\b/
+
+function collectTsFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) return collectTsFiles(full)
+    return full.endsWith('.ts') ? [full] : []
+  })
+}
+
+describe('server/api conventions', () => {
+  it('never references apiBaseUrl directly — routes must call apiFetch() instead', () => {
+    const offenders = collectTsFiles(SERVER_API_DIR)
+      .filter((file) => APIBASEURL_PATTERN.test(readFileSync(file, 'utf-8')))
+      .map((file) => relative(join(__dirname, '../..'), file))
+
+    expect(offenders).toEqual([])
+  })
+})


### PR DESCRIPTION
## Context (roadmap #8, hardening follow-up)
The BFF→backend throttle fix (portfolio-api 2.11.0 / portfolio 1.14.0) centralized every `server/api/**` call through `apiFetch()` so the real client IP gets forwarded — without it every visitor collapses into one throttle bucket at the backend. A follow-up noted there was no guard stopping a future route from calling `$fetch(`${config.apiBaseUrl}...`)` directly and silently reintroducing that bug.

## What
No ESLint setup exists in this repo (no config/script/dependency), so introducing one for a single rule felt like disproportionate scope. Instead: a static-scan Vitest test (`tests/server/api-fetch-convention.test.ts`) that walks `src/server/api/**/*.ts` and fails if any file references `apiBaseUrl` directly (only `server/utils/api.ts` may). Runs automatically in the existing `yarn test` step in CI — no new tooling, no new CI wiring.

## Verified
- Passes on the current (clean) codebase.
- **Confirmed it actually catches the regression it's meant to prevent**: temporarily reintroduced a raw `apiBaseUrl` reference in a route, watched the test fail with the exact offending file path, then reverted.
- Full suite: 245/245 green (35 files), typecheck clean — run inside the dev container per the documented host-node_modules gotcha.