### PR TITLE
🚀 Release 1.20.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.3] - 2026-07-17
+
+### Fixed
+- **`build-cv-pdf.sh` pointed at the wrong local dev port** — defaulted to the retired `localhost:3001`; now defaults to `localhost:3002`. Dev tooling only, no runtime change. (#157)
+
+### Added
+- **Regression test guarding the `apiFetch` convention** — a static-scan test now fails the suite if any `server/api/**` route references `config.apiBaseUrl` directly instead of going through the centralized `apiFetch()` helper (which forwards the real client IP for per-visitor rate limiting). (#158)
+
+---
+
 ## [1.20.2] - 2026-07-16
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-app",
-  "version": "1.20.2",
+  "version": "1.20.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/build-cv-pdf.sh
+++ b/scripts/build-cv-pdf.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # Regenerate src/public/resume.pdf from the live /cv page.
-# Run while `docker compose up` is up so http://localhost:3001/cv is reachable.
+# Run while `docker compose up` is up so http://localhost:3002/cv is reachable.
 #
 # Usage: ./scripts/build-cv-pdf.sh
 
 set -euo pipefail
 
-URL="${CV_URL:-http://localhost:3001/cv}"
+URL="${CV_URL:-http://localhost:3002/cv}"
 OUT="src/public/resume.pdf"
 
 CHROME=$(command -v google-chrome-stable || command -v google-chrome || command -v chromium || command -v chromium-browser || true)

--- a/tests/server/api-fetch-convention.test.ts
+++ b/tests/server/api-fetch-convention.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+// Every BFF → backend call must go through server/utils/api.ts's apiFetch(),
+// which is the single place `config.apiBaseUrl` is composed into a URL and
+// forwards the real client IP (see api.ts's LOAD-BEARING throttle comment).
+// A route that calls $fetch(`${config.apiBaseUrl}...`) directly bypasses that
+// IP forwarding and silently collapses every visitor back into one throttle
+// bucket. This test guards against reintroducing that pattern.
+const SERVER_API_DIR = join(__dirname, '../../src/server/api')
+const APIBASEURL_PATTERN = /\bapiBaseUrl\b/
+
+function collectTsFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) return collectTsFiles(full)
+    return full.endsWith('.ts') ? [full] : []
+  })
+}
+
+describe('server/api conventions', () => {
+  it('never references apiBaseUrl directly — routes must call apiFetch() instead', () => {
+    const offenders = collectTsFiles(SERVER_API_DIR)
+      .filter((file) => APIBASEURL_PATTERN.test(readFileSync(file, 'utf-8')))
+      .map((file) => relative(join(__dirname, '../..'), file))
+
+    expect(offenders).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Patch release with dev tooling fixes and regression test coverage. build-cv-pdf.sh now correctly defaults to the local dev port (3002) instead of the retired 3001; CI adds a static-scan guard to prevent routes from bypassing the centralized apiFetch helper, which forwards the real client IP for per-visitor rate limiting.

## Highlights

- **`build-cv-pdf.sh` pointed at the wrong local dev port** — defaulted to the retired `localhost:3001`; now defaults to `localhost:3002`. Dev tooling only, no runtime change. (#157)
- **Regression test guarding the `apiFetch` convention** — a static-scan test now fails the suite if any `server/api/**` route references `config.apiBaseUrl` directly instead of going through the centralized `apiFetch()` helper (which forwards the real client IP for per-visitor rate limiting). (#158)

## Test plan

- [x] CI \`build\` green on source PRs
- [ ] Post-merge: auto-release tags \`v1.20.3\` and publishes GitHub Release
- [ ] Post-merge: Deploy workflow succeeds on polaris2
- [ ] Post-deploy: \`curl -I https://cativo.dev/\` shows expected headers
- [ ] Post-deploy: container reports \`healthy\`
- [ ] Post-release: \`main\` merged back to \`develop\`

Refs #157 #158