### PR TITLE
feat(projects): render curated problem/role/outcome spine on detail pages (roadmap #4)

### DIFF
--- a/src/pages/projects/[id].vue
+++ b/src/pages/projects/[id].vue
@@ -70,6 +70,21 @@
       <div class="grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-0.5">
         <!-- MAIN -->
         <div class="space-y-0.5 order-2 lg:order-1 min-w-0">
+          <!-- SPINE: problem -> role -> outcome (curated recruiter-skim summary) -->
+          <div v-if="project.problem && project.role && project.outcome" class="panel">
+            <div class="panel-header">
+              <span>SPINE</span>
+            </div>
+            <dl class="grid grid-cols-[minmax(0,max-content)_1fr] gap-x-6 gap-y-4 px-6 py-6 lg:px-8">
+              <dt class="font-stamp uppercase tracking-wider text-[10px] text-nw-primary pt-1">PROBLEM</dt>
+              <dd class="text-nw-text-dim leading-relaxed">{{ project.problem }}</dd>
+              <dt class="font-stamp uppercase tracking-wider text-[10px] text-nw-primary pt-1">ROLE</dt>
+              <dd class="text-nw-text-dim leading-relaxed">{{ project.role }}</dd>
+              <dt class="font-stamp uppercase tracking-wider text-[10px] text-nw-primary pt-1">OUTCOME</dt>
+              <dd class="text-nw-text-dim leading-relaxed">{{ project.outcome }}</dd>
+            </dl>
+          </div>
+
           <!-- KEY FEATURES -->
           <div v-if="project.features && project.features.length > 0" class="panel">
             <div class="panel-header">

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -13,4 +13,7 @@ export interface Project {
     heroImage?: string;
     features?: string[];
     status?: string;
+    problem?: string;
+    role?: string;
+    outcome?: string;
 }


### PR DESCRIPTION
## What
Companion to portfolio-api PR #148 — renders the new curated `problem`/`role`/`outcome` project fields on the detail page.

- Extends the `Project` type with the 3 optional fields (BFF already passes them through verbatim, no server-side change needed).
- New SPINE panel on `pages/projects/[id].vue`, using the same `<dl>` pattern already vetted for /now's spec grids (blue labels, grey prose descriptions — per the design-evolution learning that `kv-row` is for short data pairs, not prose).
- Only renders when all three fields are present, so the 6 non-spine projects fall back to the existing raw-content-only rendering unchanged.

## Verified in a real browser (not just unit tests)
Ran both dev stacks together and checked real SSR HTML: lumira (has spine data) renders the panel with correct content; portfolio (no spine data) renders nothing. Also confirmed the em-dash characters in the curated text survive the full API → JSON → SSR → HTML pipeline intact.

## Tests
245/245 green (no new tests needed — the BFF passthrough and page-level rendering aren't covered by unit tests per this repo's existing convention: pages are excluded from coverage, and there's no e2e precedent for the public detail page), typecheck clean. Run inside the dev container per the documented host-node_modules gotcha.