### PR TITLE
🚀 Release 1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.21.0] - 2026-07-17
+
+### Added
+- **Project detail "SPINE" panel** — a curated problem → role → outcome summary now renders on project detail pages when the backend has curated content for that project, giving recruiters a skimmable summary instead of only the raw README dump. Uses the same `<dl>` label/description pattern already used on /now's spec grids. Falls back to the existing behavior (no panel) for projects without curated content. (#160)
+
+---
+
 ## [1.20.3] - 2026-07-17
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-app",
-  "version": "1.20.3",
+  "version": "1.21.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/pages/projects/[id].vue
+++ b/src/pages/projects/[id].vue
@@ -70,6 +70,21 @@
       <div class="grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-0.5">
         <!-- MAIN -->
         <div class="space-y-0.5 order-2 lg:order-1 min-w-0">
+          <!-- SPINE: problem -> role -> outcome (curated recruiter-skim summary) -->
+          <div v-if="project.problem && project.role && project.outcome" class="panel">
+            <div class="panel-header">
+              <span>SPINE</span>
+            </div>
+            <dl class="grid grid-cols-[minmax(0,max-content)_1fr] gap-x-6 gap-y-4 px-6 py-6 lg:px-8">
+              <dt class="font-stamp uppercase tracking-wider text-[10px] text-nw-primary pt-1">PROBLEM</dt>
+              <dd class="text-nw-text-dim leading-relaxed">{{ project.problem }}</dd>
+              <dt class="font-stamp uppercase tracking-wider text-[10px] text-nw-primary pt-1">ROLE</dt>
+              <dd class="text-nw-text-dim leading-relaxed">{{ project.role }}</dd>
+              <dt class="font-stamp uppercase tracking-wider text-[10px] text-nw-primary pt-1">OUTCOME</dt>
+              <dd class="text-nw-text-dim leading-relaxed">{{ project.outcome }}</dd>
+            </dl>
+          </div>
+
           <!-- KEY FEATURES -->
           <div v-if="project.features && project.features.length > 0" class="panel">
             <div class="panel-header">

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -13,4 +13,7 @@ export interface Project {
     heroImage?: string;
     features?: string[];
     status?: string;
+    problem?: string;
+    role?: string;
+    outcome?: string;
 }


### PR DESCRIPTION
## Summary

A new curated summary panel now renders on project detail pages when the backend provides structured content, replacing raw README dumps with a problem → role → outcome outline that recruiters can skim quickly.

## Highlights

- **Project detail "SPINE" panel** — a curated problem → role → outcome summary now renders on project detail pages when the backend has curated content for that project, giving recruiters a skimmable summary instead of only the raw README dump. Uses the same `<dl>` label/description pattern already used on /now's spec grids. Falls back to the existing behavior (no panel) for projects without curated content. (#160)

## Test plan

- [x] CI `build` green on source PRs
- [ ] Post-merge: auto-release tags `v1.21.0` and publishes GitHub Release
- [ ] Post-merge: Deploy workflow succeeds on polaris2
- [ ] Post-deploy: `curl -I https://cativo.dev/` shows expected headers
- [ ] Post-deploy: container reports `healthy`
- [ ] Post-release: `main` merged back to `develop`
- [ ] Verify SPINE panel renders on live project detail page (pending portfolio-api 2.17.0 content population)

Refs #160