### PR TITLE
fix(content): correct stale lumira/nightwire download counts

### DIFF
--- a/src/pages/about.vue
+++ b/src/pages/about.vue
@@ -357,13 +357,13 @@ const profile: Profile = {
 const ossPackages = [
   {
     name: 'lumira',
-    downloads: '~3.4K dl/mo',
+    downloads: '~1.8K dl/mo',
     stack: 'TypeScript · npm',
     description: 'Real-time statusline HUD for Claude Code and Qwen Code. Session analytics, latency overhead widget, quota projection. Zero deps.'
   },
   {
     name: 'nightwire',
-    downloads: '~475 dl/mo',
+    downloads: '~84 dl/mo',
     stack: 'CSS · npm',
     description: 'Dark cyberpunk UI design system. Semantic color roles, neon palette, CLI installer.'
   }

--- a/src/pages/cv.vue
+++ b/src/pages/cv.vue
@@ -158,12 +158,12 @@ const print = () => {
         <h2>Open Source · npm</h2>
         <ul class="projects">
           <li>
-            <strong>lumira</strong> <span class="proj-tag">~3.4K dl/mo</span> — Real-time statusline HUD
+            <strong>lumira</strong> <span class="proj-tag">~1.8K dl/mo</span> — Real-time statusline HUD
             for Claude Code and Qwen Code. Session analytics, latency overhead widget, quota projection.
             Zero deps. <em>TypeScript, npm.</em>
           </li>
           <li>
-            <strong>nightwire</strong> <span class="proj-tag">~475 dl/mo</span> — Dark cyberpunk UI design
+            <strong>nightwire</strong> <span class="proj-tag">~84 dl/mo</span> — Dark cyberpunk UI design
             system. Semantic color roles, neon palette, CLI installer. <em>CSS, npm.</em>
           </li>
         </ul>

--- a/src/pages/now.vue
+++ b/src/pages/now.vue
@@ -129,7 +129,7 @@
       <div class="panel-body p-0">
         <dl class="grid grid-cols-[minmax(0,max-content)_1fr] gap-x-6 gap-y-4 px-6 py-6 lg:px-8">
           <dt class="font-stamp uppercase tracking-wider text-[10px] text-nw-primary pt-1">LUMIRA</dt>
-          <dd class="text-nw-text-dim leading-relaxed">Real-time statusline for Claude Code &amp; Qwen Code · TypeScript, zero runtime deps · v1.14 shipped with subagent-aware rendering and git-worktree fallback · published on <a href="https://www.npmjs.com/package/lumira" target="_blank" rel="noopener noreferrer" class="text-nw-primary hover:text-nw-primary-hot">npm</a> · ~4k downloads/month</dd>
+          <dd class="text-nw-text-dim leading-relaxed">Real-time statusline for Claude Code &amp; Qwen Code · TypeScript, zero runtime deps · v1.14 shipped with subagent-aware rendering and git-worktree fallback · published on <a href="https://www.npmjs.com/package/lumira" target="_blank" rel="noopener noreferrer" class="text-nw-primary hover:text-nw-primary-hot">npm</a> · ~1.8k downloads/month</dd>
           <dt class="font-stamp uppercase tracking-wider text-[10px] text-nw-primary pt-1">NOVA-ID</dt>
           <dd class="text-nw-text-dim leading-relaxed">Self-hosted identity &amp; SSO platform (OIDC via Ory Hydra) with a role/permissions demo API · actively hardening auth flows and audit logging</dd>
           <dt class="font-stamp uppercase tracking-wider text-[10px] text-nw-primary pt-1">NIGHTWIRE</dt>


### PR DESCRIPTION
/about, /cv, and /now still showed lumira ~3.4K dl/mo and nightwire ~475 dl/mo. Verified against the live npm registry today: lumira is actually ~1.8K/mo (1,753), nightwire ~84/mo (82). Content-only fix.