### PR TITLE
🚀 Release 1.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.21.1] - 2026-07-23
+
+### Fixed
+- **Stale lumira/nightwire download counts on /about, /cv, and /now** — still showed lumira ~3.4K dl/mo and nightwire ~475 dl/mo. Corrected to the verified live npm registry numbers (~1.8K/mo and ~84/mo respectively). (#162)
+
+---
+
 ## [1.21.0] - 2026-07-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-app",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/pages/about.vue
+++ b/src/pages/about.vue
@@ -357,13 +357,13 @@ const profile: Profile = {
 const ossPackages = [
   {
     name: 'lumira',
-    downloads: '~3.4K dl/mo',
+    downloads: '~1.8K dl/mo',
     stack: 'TypeScript · npm',
     description: 'Real-time statusline HUD for Claude Code and Qwen Code. Session analytics, latency overhead widget, quota projection. Zero deps.'
   },
   {
     name: 'nightwire',
-    downloads: '~475 dl/mo',
+    downloads: '~84 dl/mo',
     stack: 'CSS · npm',
     description: 'Dark cyberpunk UI design system. Semantic color roles, neon palette, CLI installer.'
   }

--- a/src/pages/cv.vue
+++ b/src/pages/cv.vue
@@ -158,12 +158,12 @@ const print = () => {
         <h2>Open Source · npm</h2>
         <ul class="projects">
           <li>
-            <strong>lumira</strong> <span class="proj-tag">~3.4K dl/mo</span> — Real-time statusline HUD
+            <strong>lumira</strong> <span class="proj-tag">~1.8K dl/mo</span> — Real-time statusline HUD
             for Claude Code and Qwen Code. Session analytics, latency overhead widget, quota projection.
             Zero deps. <em>TypeScript, npm.</em>
           </li>
           <li>
-            <strong>nightwire</strong> <span class="proj-tag">~475 dl/mo</span> — Dark cyberpunk UI design
+            <strong>nightwire</strong> <span class="proj-tag">~84 dl/mo</span> — Dark cyberpunk UI design
             system. Semantic color roles, neon palette, CLI installer. <em>CSS, npm.</em>
           </li>
         </ul>

--- a/src/pages/now.vue
+++ b/src/pages/now.vue
@@ -129,7 +129,7 @@
       <div class="panel-body p-0">
         <dl class="grid grid-cols-[minmax(0,max-content)_1fr] gap-x-6 gap-y-4 px-6 py-6 lg:px-8">
           <dt class="font-stamp uppercase tracking-wider text-[10px] text-nw-primary pt-1">LUMIRA</dt>
-          <dd class="text-nw-text-dim leading-relaxed">Real-time statusline for Claude Code &amp; Qwen Code · TypeScript, zero runtime deps · v1.14 shipped with subagent-aware rendering and git-worktree fallback · published on <a href="https://www.npmjs.com/package/lumira" target="_blank" rel="noopener noreferrer" class="text-nw-primary hover:text-nw-primary-hot">npm</a> · ~4k downloads/month</dd>
+          <dd class="text-nw-text-dim leading-relaxed">Real-time statusline for Claude Code &amp; Qwen Code · TypeScript, zero runtime deps · v1.14 shipped with subagent-aware rendering and git-worktree fallback · published on <a href="https://www.npmjs.com/package/lumira" target="_blank" rel="noopener noreferrer" class="text-nw-primary hover:text-nw-primary-hot">npm</a> · ~1.8k downloads/month</dd>
           <dt class="font-stamp uppercase tracking-wider text-[10px] text-nw-primary pt-1">NOVA-ID</dt>
           <dd class="text-nw-text-dim leading-relaxed">Self-hosted identity &amp; SSO platform (OIDC via Ory Hydra) with a role/permissions demo API · actively hardening auth flows and audit logging</dd>
           <dt class="font-stamp uppercase tracking-wider text-[10px] text-nw-primary pt-1">NIGHTWIRE</dt>


### PR DESCRIPTION
## Summary

Patch release to correct stale lumira/nightwire download counts on portfolio pages. The counts on /about, /cv, and /now still showed outdated npm registry figures and have been updated to reflect current live values.

## Highlights

- **Stale lumira/nightwire download counts on /about, /cv, and /now** — still showed lumira ~3.4K dl/mo and nightwire ~475 dl/mo. Corrected to the verified live npm registry numbers (~1.8K/mo and ~84/mo respectively). (#162)

## Test plan

- [x] CI `build` green on source PRs
- [ ] Post-merge: auto-release tags `v1.21.1` and publishes GitHub Release
- [ ] Post-merge: Deploy workflow succeeds on polaris2
- [ ] Post-deploy: `curl -I https://cativo.dev/` shows expected headers
- [ ] Post-deploy: container reports `healthy`
- [ ] Post-release: `main` merged back to `develop`

Refs #162