### PR TITLE
feat(about): link Payment Service highlight to the new case study

### DIFF
--- a/src/pages/about.vue
+++ b/src/pages/about.vue
@@ -90,6 +90,15 @@
                 <span class="text-nw-primary shrink-0 select-none" aria-hidden="true">▸</span>
                 <span>
                   <span v-if="part.lead" class="text-nw-text font-medium">{{ part.lead }} — </span>{{ part.rest }}
+                  <a
+                    v-if="part.lead === 'Payment Service'"
+                    href="https://blog.cativo.dev/payment-service-one-interface-many-processors/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-nw-primary hover:text-nw-primary-hot whitespace-nowrap"
+                  >
+                    Read the full case study →
+                  </a>
                 </span>
               </li>
             </ul>


### PR DESCRIPTION
Roadmap #5 — the Payment Service case study is live at https://blog.cativo.dev/payment-service-one-interface-many-processors/. Adds a 'Read the full case study →' link under the Payment Service highlight on /about, using the same external-link pattern already used in the GET IN TOUCH panel.

Verified in the dev container: renders correctly, correct href, surrounding highlight text intact. 245/245 tests green, typecheck clean.