### PR TITLE
🚀 Release 1.21.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.21.2] - 2026-07-23
+
+### Added
+- **Link to the new Payment Service case study on /about** — the "Read the full case study →" link under the Payment Service highlight now points to the published blog post at blog.cativo.dev. (#164)
+
+---
+
 ## [1.21.1] - 2026-07-23
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-app",
-  "version": "1.21.1",
+  "version": "1.21.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/pages/about.vue
+++ b/src/pages/about.vue
@@ -90,6 +90,15 @@
                 <span class="text-nw-primary shrink-0 select-none" aria-hidden="true">▸</span>
                 <span>
                   <span v-if="part.lead" class="text-nw-text font-medium">{{ part.lead }} — </span>{{ part.rest }}
+                  <a
+                    v-if="part.lead === 'Payment Service'"
+                    href="https://blog.cativo.dev/payment-service-one-interface-many-processors/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-nw-primary hover:text-nw-primary-hot whitespace-nowrap"
+                  >
+                    Read the full case study →
+                  </a>
                 </span>
               </li>
             </ul>


### PR DESCRIPTION
## Summary

Content-only link addition: the Payment Service highlight on /about now includes a "Read the full case study →" link pointing to the published blog post at blog.cativo.dev, making it easier for recruiters and visitors to discover the full case study.

## Highlights

- **Link to the new Payment Service case study on /about** — the "Read the full case study →" link under the Payment Service highlight now points to the published blog post at blog.cativo.dev. (#164)

## Test plan

- [x] CI `build` green on source PRs
- [ ] Post-merge: auto-release tags `v1.21.2` and publishes GitHub Release
- [ ] Post-merge: Deploy workflow succeeds on polaris2
- [ ] Post-deploy: `curl -I https://cativo.dev/about` shows expected headers
- [ ] Post-deploy: container reports `healthy`
- [ ] Post-release: `main` merged back to `develop`

Refs #164